### PR TITLE
Send output of exectued commands to stdout and stderr

### DIFF
--- a/src/go-git-duet/git_config.go
+++ b/src/go-git-duet/git_config.go
@@ -3,6 +3,7 @@ package duet
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -159,5 +160,9 @@ func (gc *GitConfig) configCommand(args ...string) *exec.Cmd {
 		config = append(config, "--global")
 	}
 	config = append(config, args...)
-	return exec.Command("git", config...)
+	cmd := exec.Command("git", config...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd
 }

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -85,3 +85,10 @@ load test_helper
   assert_line "GIT_AUTHOR_NAME='Abraham Lincoln'"
   assert_line "GIT_AUTHOR_EMAIL='abe@hamster.info.local'"
 }
+
+@test "prints error output when commands fail" {
+  cd /tmp
+  run git solo al
+  assert_failure
+  assert_line "error: could not lock config file .git/config: No such file or directory"
+}


### PR DESCRIPTION
Makes determining why errors occurred simpler (e.g. when using git-duet
outside of a repository).

Addresses #3 
