### PR TITLE
Add mechanism to automatically switch author and committer between commits

### DIFF
--- a/src/go-git-duet/configuration.go
+++ b/src/go-git-duet/configuration.go
@@ -9,11 +9,12 @@ import (
 
 // Configuration represents package configuration (shared by commands)
 type Configuration struct {
-	Namespace   string
-	PairsFile   string
-	EmailLookup string
-	Global      bool
-	StaleCutoff time.Duration
+	Namespace    string
+	PairsFile    string
+	EmailLookup  string
+	Global       bool
+	RotateAuthor bool
+	StaleCutoff  time.Duration
 }
 
 // NewConfiguration initializes Configuration from the environment
@@ -32,6 +33,10 @@ func NewConfiguration() (config *Configuration, err error) {
 	}
 
 	if config.Global, err = strconv.ParseBool(getenvDefault("GIT_DUET_GLOBAL", "0")); err != nil {
+		return nil, err
+	}
+
+	if config.RotateAuthor, err = strconv.ParseBool(getenvDefault("GIT_DUET_ROTATE_AUTHOR", "0")); err != nil {
 		return nil, err
 	}
 

--- a/src/go-git-duet/git-duet-commit/main.go
+++ b/src/go-git-duet/git-duet-commit/main.go
@@ -15,18 +15,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	gitConfig := &duet.GitConfig{
-		Namespace: configuration.Namespace,
-	}
-
-	author, err := gitConfig.GetAuthor()
+	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	if author == nil {
-		fmt.Println("no duet set")
+	author, err := gitConfig.GetAuthor()
+	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 
@@ -57,5 +54,12 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+
+	if configuration.RotateAuthor {
+		if err = gitConfig.RotateAuthor(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 }

--- a/src/go-git-duet/git-duet/main.go
+++ b/src/go-git-duet/git-duet/main.go
@@ -29,12 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	gitConfig := &duet.GitConfig{
-		Namespace: configuration.Namespace,
-		Global:    configuration.Global || *global,
-	}
-
 	if getopt.NArgs() == 0 {
+		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
 		author, err := gitConfig.GetAuthor()
 		if err != nil {
 			fmt.Println(err)
@@ -46,9 +47,21 @@ func main() {
 			os.Exit(1)
 		}
 
+		if committer == nil {
+			committer = author
+		}
+
 		printAuthor(author)
 		printCommitter(committer)
 		os.Exit(0)
+	}
+
+	gitConfig := &duet.GitConfig{
+		Namespace: configuration.Namespace,
+	}
+
+	if configuration.Global || *global {
+		gitConfig.Scope = duet.Global
 	}
 
 	if getopt.NArgs() != 2 {

--- a/src/go-git-duet/git-solo/main.go
+++ b/src/go-git-duet/git-solo/main.go
@@ -31,7 +31,6 @@ func main() {
 
 	gitConfig := &duet.GitConfig{
 		Namespace: configuration.Namespace,
-		Global:    configuration.Global || *global,
 	}
 
 	if getopt.NArgs() == 0 {
@@ -43,6 +42,10 @@ func main() {
 
 		printAuthor(author)
 		os.Exit(0)
+	}
+
+	if configuration.Global || *global {
+		gitConfig.Scope = duet.Global
 	}
 
 	pairs, err := duet.NewPairsFromFile(configuration.PairsFile, configuration.EmailLookup)

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -95,3 +95,13 @@ load test_helper
   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
+
+@test "honors source when printing config" {
+  git duet -q -g fb jd
+  git solo fb
+  run git duet
+  assert_line "GIT_AUTHOR_NAME='Frances Bar'"
+  assert_line "GIT_AUTHOR_EMAIL='f.bar@hamster.info.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+}

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -61,6 +61,13 @@ load test_helper
   clear_custom_email_template
 }
 
+@test "unsets git committer email after duet" {
+  git duet -q jd fb
+  git solo -q jd
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_equal 1 $status
+}
+
 @test "respects GIT_DUET_GLOBAL" {
   GIT_DUET_GLOBAL=1 git solo jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
@@ -77,6 +84,13 @@ load test_helper
   git solo -g -q jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
   assert_success 'Jane Doe'
+}
+
+@test "unsets git committer email after duet globally" {
+  git duet -g -q jd fb
+  git solo -g -q jd
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_equal 1 $status
 }
 
 @test "prints current config" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -3,6 +3,9 @@ setup() {
 
   mkdir "$GIT_DUET_TEST_DIR"
 
+  unset GIT_DUET_GLOBAL
+  unset GIT_DUET_ROTATE_AUTHOR
+
   export GIT_DUET_CONFIG_NAMESPACE='foo.bar'
   export GIT_DUET_AUTHORS_FILE="${GIT_DUET_TEST_DIR}/.git-authors"
   export GIT_DUET_TEST_LOOKUP="${GIT_DUET_TEST_DIR}/email-lookup"
@@ -43,8 +46,13 @@ teardown() {
 }
 
 add_file() {
-  touch file.txt
-  git add file.txt
+  if [ $# -eq 0 ]; then
+    touch file.txt
+    git add file.txt
+  else
+    touch $1
+    git add $1
+  fi
 }
 
 set_custom_email_template() {


### PR DESCRIPTION
A while ago, my team made the switch to `git-duet` but some of the folks went back to `git-pair` since it randomly selects an author from the pairs; they like this as it helps distribute the 'green dots' between people while they're pairing.

Since I'm not a fan of how `git-pair` generates fictitious email addresses or loses track of one of the authors, I'd like to get everyone back to using pair.

This pull request adds code to swap the author and committer at the end of every commit when the `GIT_DUET_ROTATE_AUTHOR` environment variable is set. This mode of operation should distribute the 'green dots' in fair and deterministic way.
