### PR TITLE
When resetting committer, set the fields to empty string

### DIFF
--- a/src/go-git-duet/git_config.go
+++ b/src/go-git-duet/git_config.go
@@ -21,10 +21,10 @@ type GitConfig struct {
 
 // ClearCommitter removes committer name/email from config
 func (gc *GitConfig) ClearCommitter() (err error) {
-	if err = gc.unsetKey("git-committer-name"); err != nil {
+	if err = gc.setKey("git-committer-name", ""); err != nil {
 		return err
 	}
-	if err = gc.unsetKey("git-committer-name"); err != nil {
+	if err = gc.setKey("git-committer-email", ""); err != nil {
 		return err
 	}
 	return nil
@@ -126,20 +126,6 @@ func (gc *GitConfig) getKey(key string) (value string, err error) {
 		return "", err
 	}
 	return strings.TrimSpace(output.String()), nil
-}
-
-func (gc *GitConfig) unsetKey(key string) (err error) {
-	if err = newIgnorableCommand(
-		gc.configCommand("--unset-all", fmt.Sprintf("%s.%s", gc.Namespace, key)),
-		5).Run(); err != nil {
-		return err
-	}
-	if err = gc.configCommand(
-		fmt.Sprintf("%s.%s", gc.Namespace, "mtime"),
-		strconv.FormatInt(time.Now().Unix(), 10)).Run(); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (gc *GitConfig) setKey(key, value string) (err error) {

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -42,6 +42,16 @@ load test_helper
   assert_failure ''
 }
 
+@test "does not read committer from global if local author is set" {
+  git duet -g -q jd fb
+  git solo -q on
+  add_file
+  git duet-commit -q -m 'Testing omitting signoff'
+  cat .git/COMMIT_EDITMSG
+  run grep 'Signed-off-by' .git/COMMIT_EDITMSG
+  assert_equal 1 $status
+}
+
 @test "rejects commits with no author" {
   add_file
   run git duet-commit -q -m 'Testing commit with no author'


### PR DESCRIPTION
Avoids the issue where `git config` may read the author from local, but
the committer from global.

Addresses #11 
