### PR TITLE
Add author and committer initials as variables in git config.

### DIFF
--- a/src/git-duet/git_config.go
+++ b/src/git-duet/git_config.go
@@ -55,6 +55,9 @@ func GetAuthorConfig(namespace string) (config *GitConfig, err error) {
 
 // ClearCommitter removes committer name/email from config
 func (gc *GitConfig) ClearCommitter() (err error) {
+	if err = gc.unsetKey("git-committer-initials"); err != nil {
+		return err
+	}
 	if err = gc.unsetKey("git-committer-name"); err != nil {
 		return err
 	}

--- a/src/git-duet/git_config.go
+++ b/src/git-duet/git_config.go
@@ -112,6 +112,9 @@ func (gc *GitConfig) RotateAuthor() (err error) {
 }
 
 func (gc *GitConfig) setAuthor(author *Pair) (err error) {
+	if err = gc.setKey("git-author-initials", author.Initials); err != nil {
+		return err
+	}
 	if err = gc.setKey("git-author-name", author.Name); err != nil {
 		return err
 	}
@@ -122,6 +125,9 @@ func (gc *GitConfig) setAuthor(author *Pair) (err error) {
 }
 
 func (gc *GitConfig) setCommitter(committer *Pair) (err error) {
+	if err = gc.setKey("git-committer-initials", committer.Initials); err != nil {
+		return err
+	}
 	if err = gc.setKey("git-committer-name", committer.Name); err != nil {
 		return err
 	}
@@ -133,6 +139,11 @@ func (gc *GitConfig) setCommitter(committer *Pair) (err error) {
 
 // GetAuthor returns the currently configured author (nil if none)
 func (gc *GitConfig) GetAuthor() (pair *Pair, err error) {
+	initials, err := gc.getKey("git-author-initials")
+	if err != nil {
+		return nil, err
+	}
+
 	name, err := gc.getKey("git-author-name")
 	if err != nil {
 		return nil, err
@@ -143,11 +154,12 @@ func (gc *GitConfig) GetAuthor() (pair *Pair, err error) {
 		return nil, err
 	}
 
-	if name == "" || email == "" {
+	if name == "" || initials == "" || email == "" {
 		return nil, nil
 	}
 
 	return &Pair{
+		Initials: initials,
 		Name:  name,
 		Email: email,
 	}, nil
@@ -155,6 +167,11 @@ func (gc *GitConfig) GetAuthor() (pair *Pair, err error) {
 
 // GetCommitter returns the currently configured committer (nil if none)
 func (gc *GitConfig) GetCommitter() (pair *Pair, err error) {
+	initials, err := gc.getKey("git-committer-initials")
+	if err != nil {
+		return nil, err
+	}
+
 	name, err := gc.getKey("git-committer-name")
 	if err != nil {
 		return nil, err
@@ -165,11 +182,12 @@ func (gc *GitConfig) GetCommitter() (pair *Pair, err error) {
 		return nil, err
 	}
 
-	if name == "" || email == "" {
+	if name == "" || initials == "" || email == "" {
 		return nil, nil
 	}
 
 	return &Pair{
+		Initials: initials,
 		Name:  name,
 		Email: email,
 	}, nil
@@ -213,6 +231,7 @@ func (gc *GitConfig) unsetKey(key string) (err error) {
 		5).Run(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -220,6 +239,7 @@ func (gc *GitConfig) setKey(key, value string) (err error) {
 	if err = gc.configCommand(fmt.Sprintf("%s.%s", gc.Namespace, key), value).Run(); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -2,6 +2,12 @@
 
 load test_helper
 
+@test "sets the git user initials" {
+  git duet -q jd fb
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+  assert_success 'jd'
+}
+
 @test "sets the git user name" {
   git duet -q jd fb
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
@@ -12,6 +18,12 @@ load test_helper
   git duet -q jd fb
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
   assert_success 'jane@hamsters.biz.local'
+}
+
+@test "sets the git committer initials" {
+  git duet -q jd fb
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+  assert_success 'fb'
 }
 
 @test "caches the git committer name" {
@@ -56,6 +68,12 @@ load test_helper
   assert_success 'jane@hamsters.biz.local'
 }
 
+@test "sets the git user initials globally" {
+  git duet -g -q jd fb
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+  assert_success 'jd'
+}
+
 @test "sets the git user name globally" {
   git duet -g -q jd fb
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
@@ -66,6 +84,12 @@ load test_helper
   git duet -g -q jd fb
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
   assert_success 'Frances Bar'
+}
+
+@test "sets the git committer initials globally" {
+  git duet -g -q jd fb
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+  assert_success 'fb'
 }
 
 @test "sets the git committer name globally" {

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -74,6 +74,13 @@ load test_helper
   assert_equal 1 $status
 }
 
+@test "unsets git committer initials after duet" {
+  git duet -q jd fb
+  git solo -q jd
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+  assert_equal 1 $status
+}
+
 @test "respects GIT_DUET_GLOBAL" {
   GIT_DUET_GLOBAL=1 git solo jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -13,6 +13,12 @@ load test_helper
   assert_success ""
 }
 
+@test "caches the git user initials as author initials" {
+  git solo -q jd
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+  assert_success 'jd'
+}
+
 @test "caches the git user name as author name" {
   git solo -q jd
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"


### PR DESCRIPTION
I think it will be great if we make available git-author-initials and git-commiter-initials as variables in git config. This will possible to use them in bash extensions as bash-it to print the current committer and author like that:

```
jd+fb $ git status
```
