### PR TITLE
Proof of concept: git team

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,3 +327,7 @@ See issue #8 for more details.
 ### Building
 
 Uses [`gb`](http://getgb.io/) for building and vendor management.
+
+### Teams
+
+Totally a thing!

--- a/src/git-duet/git-team/main.go
+++ b/src/git-duet/git-team/main.go
@@ -6,7 +6,7 @@ import (
 
 	"code.google.com/p/getopt"
 
-	"git-duet"
+	duet "git-duet"
 )
 
 func main() {
@@ -63,8 +63,8 @@ func main() {
 		gitConfig.Scope = duet.Global
 	}
 
-	if getopt.NArgs() != 2 {
-		fmt.Println("must specify two sets of initials")
+	if getopt.NArgs() <= 2 {
+		fmt.Println("must specify more than two sets of initials")
 		os.Exit(1)
 	}
 
@@ -79,9 +79,23 @@ func main() {
 		fmt.Println(err)
 		os.Exit(86)
 	}
+
 	if err = gitConfig.SetAuthor(author); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+
+	number_of_committers := getopt.NArgs() - 1
+	committers := make([]*duet.Pair, number_of_committers)
+
+	for i := 1; i < getopt.NArgs(); i++ {
+		committer, err := pairs.ByInitials(getopt.Arg(i))
+		if err == nil {
+			committers[i-1] = committer
+		} else {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 
 	committer, err := pairs.ByInitials(getopt.Arg(1))

--- a/src/git-duet/git-team/main.go
+++ b/src/git-duet/git-team/main.go
@@ -98,11 +98,8 @@ func main() {
 		}
 	}
 
-	committer, err := pairs.ByInitials(getopt.Arg(1))
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(86)
-	}
+	committer := makeTeamCommitter(committers)
+
 	if err = gitConfig.SetCommitter(committer); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -130,4 +127,20 @@ func printCommitter(committer *duet.Pair) {
 
 	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committer.Name)
 	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committer.Email)
+}
+
+func makeTeamCommitter(arrayOfCommitters []*duet.Pair) (committer *duet.Pair) {
+	var returnCommitter duet.Pair
+	for index, pointerToPair := range arrayOfCommitters {
+		tempCommitter := *pointerToPair
+		if index > 0 {
+			returnCommitter.Initials += ", "
+			returnCommitter.Name += ", "
+			returnCommitter.Email += ", "
+		}
+		returnCommitter.Initials += tempCommitter.Initials
+		returnCommitter.Name += tempCommitter.Name
+		returnCommitter.Email += tempCommitter.Email
+	}
+	return &returnCommitter
 }

--- a/src/git-duet/git-team/main.go
+++ b/src/git-duet/git-team/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"code.google.com/p/getopt"
+
+	"git-duet"
+)
+
+func main() {
+	var (
+		quiet  = getopt.BoolLong("quiet", 'q', "Silence output")
+		global = getopt.BoolLong("global", 'g', "Change global config")
+		help   = getopt.BoolLong("help", 'h', "Help")
+	)
+
+	getopt.Parse()
+
+	if *help {
+		getopt.Usage()
+		os.Exit(0)
+	}
+
+	configuration, err := duet.NewConfiguration()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if getopt.NArgs() == 0 {
+		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		author, err := gitConfig.GetAuthor()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		committer, err := gitConfig.GetCommitter()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if committer == nil {
+			committer = author
+		}
+
+		printAuthor(author)
+		printCommitter(committer)
+		os.Exit(0)
+	}
+
+	gitConfig := &duet.GitConfig{
+		Namespace: configuration.Namespace,
+	}
+	if configuration.Global || *global {
+		gitConfig.Scope = duet.Global
+	}
+
+	if getopt.NArgs() != 2 {
+		fmt.Println("must specify two sets of initials")
+		os.Exit(1)
+	}
+
+	pairs, err := duet.NewPairsFromFile(configuration.PairsFile, configuration.EmailLookup)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
+
+	author, err := pairs.ByInitials(getopt.Arg(0))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(86)
+	}
+	if err = gitConfig.SetAuthor(author); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	committer, err := pairs.ByInitials(getopt.Arg(1))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(86)
+	}
+	if err = gitConfig.SetCommitter(committer); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if !*quiet {
+		printAuthor(author)
+		printCommitter(committer)
+	}
+}
+
+func printAuthor(author *duet.Pair) {
+	if author == nil {
+		return
+	}
+
+	fmt.Printf("GIT_AUTHOR_NAME='%s'\n", author.Name)
+	fmt.Printf("GIT_AUTHOR_EMAIL='%s'\n", author.Email)
+}
+
+func printCommitter(committer *duet.Pair) {
+	if committer == nil {
+		return
+	}
+
+	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committer.Name)
+	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committer.Email)
+}

--- a/src/git-duet/git_config.go
+++ b/src/git-duet/git_config.go
@@ -103,15 +103,50 @@ func (gc *GitConfig) RotateAuthor() (err error) {
 	}
 
 	if committer != nil {
-		if err = gc.setAuthor(committer); err != nil {
+		var newAuthor, newCommitter *Pair
+		if strings.Contains(committer.Initials, ",") {
+			newAuthor, newCommitter = makeRotatedTeam(author, committer)
+		} else {
+			newAuthor = committer
+			newCommitter = author
+		}
+
+		if err = gc.setAuthor(newAuthor); err != nil {
 			return err
 		}
-		if err = gc.setCommitter(author); err != nil {
+		if err = gc.setCommitter(newCommitter); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func makeRotatedTeam(teamAuthor *Pair, teamCommitter *Pair) (newAuthor *Pair, newCommitter *Pair) {
+	authorInitials := teamAuthor.Initials
+	authorName := teamAuthor.Name
+	authorEmail := teamAuthor.Email
+	committerInitialsList := strings.Split(teamCommitter.Initials, ", ")
+	committerNamesList := strings.Split(teamCommitter.Name, ", ")
+	committerEmailsList := strings.Split(teamCommitter.Email, ", ")
+	InitialsList := append(committerInitialsList, authorInitials)
+	EmailsList := append(committerEmailsList, authorEmail)
+	NamesList := append(committerNamesList, authorName)
+	newAuthorInitials, newTeamCommitterInitials := InitialsList[0], strings.Join(InitialsList[1:], ", ")
+	newAuthorName, newTeamCommitterName := NamesList[0], strings.Join(NamesList[1:], ", ")
+	newAuthorEmail, newTeamCommitterEmail := EmailsList[0], strings.Join(EmailsList[1:], ", ")
+	newAuthor = &Pair{
+		Name:     newAuthorName,
+		Email:    newAuthorEmail,
+		Username: "Hello World",
+		Initials: newAuthorInitials}
+	newCommitter = &Pair{
+		Name:     newTeamCommitterName,
+		Email:    newTeamCommitterEmail,
+		Username: "Hello World",
+		Initials: newTeamCommitterInitials,
+	}
+	return newAuthor, newCommitter
 }
 
 func (gc *GitConfig) setAuthor(author *Pair) (err error) {

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -68,6 +68,28 @@ load test_helper
   assert_success 'f.bar@hamster.info.local'
 }
 
+@test "GIT_DUET_ROTATE_AUTHOR can understand and rotate teams" {
+  git team -q -g jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane@hamsters.biz.local'
+
+  add_file first.txt
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-commit -q -m 'Testing jd as author, fb and on as team committers'
+  assert_success
+
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'f.bar@hamster.info.local'
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_success 'oscar@hamster.info.local, jane@hamsters.biz.local'
+
+  add_file second.txt
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-commit -q -m 'Testing fb as author, on and jd as team committers'
+  assert_success
+
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'oscar@hamster.info.local'
+}
+
 @test "does not update mtime when rotating committer" {
   git duet -q jd fb
   git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"

--- a/test/git-team.bats
+++ b/test/git-team.bats
@@ -32,100 +32,104 @@ load test_helper
   assert_success 'Frances Bar, Oscar'
 }
 
-# @test "caches the git committer email" {
-#   git duet -q jd fb on
-#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
-#   assert_success 'f.bar@hamster.info.local'
-# }
-# 
-# @test "looks up external author email" {
-#   GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git duet -q jd fb
-#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
-#   assert_success 'jane_doe@lookie.me.local'
-# }
-# 
-# @test "looks up external committer email" {
-#   GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git duet -q jd fb
-#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
-#   assert_success 'fb9000@dalek.info.local'
-# }
-# 
-# @test "uses custom email template for author when provided" {
-#   local suffix=$RANDOM
-# 
-#   set_custom_email_template "{{with split .Name \" \"}}{{with index . 0}}{{toLower . }}{{end}}.{{with index . 1}}{{toLower . }}{{end}}{{end}}$suffix@mompopshop.local"
-# 
-#   git duet -q zp fb
-#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
-#   assert_success "zubaz.pants$suffix@mompopshop.local"
-# 
-#   clear_custom_email_template
-# }
-# 
-# @test "sets the git user email globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
-#   assert_success 'jane@hamsters.biz.local'
-# }
-# 
-# @test "sets the git user initials globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
-#   assert_success 'jd'
-# }
-# 
-# @test "sets the git user name globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
-#   assert_success 'Jane Doe'
-# }
-# 
-# @test "sets the git committer email globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
-#   assert_success 'Frances Bar'
-# }
-# 
-# @test "sets the git committer initials globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
-#   assert_success 'fb'
-# }
-# 
-# @test "sets the git committer name globally" {
-#   git duet -g -q jd fb
-#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
-#   assert_success 'f.bar@hamster.info.local'
-# }
-# 
-# @test "output is displayed" {
-#   run git duet jd fb
-#   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
-#   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
-#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
-#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
-# }
-# 
-# @test "output is not displayed when quieted" {
-#   run git duet -q jd fb
-#   assert_success ""
-# }
-# 
-# @test "prints current config" {
-#   git duet -q jd fb
-#   run git duet
-#   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
-#   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
-#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
-#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
-# }
-# 
-# @test "honors source when printing config" {
-#   git duet -q -g fb jd
-#   git solo fb
-#   run git duet
-#   assert_line "GIT_AUTHOR_NAME='Frances Bar'"
-#   assert_line "GIT_AUTHOR_EMAIL='f.bar@hamster.info.local'"
-#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
-#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
-# }
+@test "caches the git committer email" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_success 'f.bar@hamster.info.local, oscar@hamster.info.local'
+}
+
+@test "looks up external author email" {
+  GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane_doe@lookie.me.local'
+}
+
+@test "looks up external committer email" {
+  GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git team -q on jd fb
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_success 'jane_doe@lookie.me.local, fb9000@dalek.info.local'
+}
+
+@test "sets the git user email globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane@hamsters.biz.local'
+}
+
+@test "sets the git user initials globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+  assert_success 'jd'
+}
+
+@test "sets the git user name globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
+  assert_success 'Jane Doe'
+}
+
+@test "sets the git committer email globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
+  assert_success 'Frances Bar, Oscar'
+}
+
+@test "sets the git committer initials globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+  assert_success 'fb, on'
+}
+
+@test "sets the git committer name globally" {
+  git team -g -q jd fb on
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_success 'f.bar@hamster.info.local, oscar@hamster.info.local'
+}
+
+@test "output is displayed" {
+  run git team jd fb on
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar, Oscar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local, oscar@hamster.info.local'"
+}
+
+@test "output is not displayed when quieted" {
+  run git team -q jd fb on
+  assert_success ""
+}
+
+@test "prints current config" {
+  git team -q jd fb on
+  run git duet
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar, Oscar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local, oscar@hamster.info.local'"
+}
+
+@test "honors source when printing config" {
+  git team -q -g fb jd on
+  git solo fb
+  run git team
+  assert_line "GIT_AUTHOR_NAME='Frances Bar'"
+  assert_line "GIT_AUTHOR_EMAIL='f.bar@hamster.info.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+}
+
+@test "lists the alpha of the team as author in the log" {
+  git team -q jd fb on
+  add_file
+  git duet-commit -q -m 'testing set of alpha as author'
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "lists the rest of the team as committer in the log" {
+  git team -q jd fb on
+  add_file
+  git duet-commit -q -m 'testing set of omega as committer'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar, Oscar <f.bar@hamster.info.local, oscar@hamster.info.local>'
+}

--- a/test/git-team.bats
+++ b/test/git-team.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "sets the git user initials" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+  assert_success 'jd'
+}
+
+@test "sets the git user name" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
+  assert_success 'Jane Doe'
+}
+
+@test "sets the git user email" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane@hamsters.biz.local'
+}
+
+@test "sets the git committer initials" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+  assert_success 'fb, on'
+}
+
+@test "caches the git committer name" {
+  git team -q jd fb on
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
+  assert_success 'Frances Bar, Oscar'
+}
+
+# @test "caches the git committer email" {
+#   git duet -q jd fb on
+#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+#   assert_success 'f.bar@hamster.info.local'
+# }
+# 
+# @test "looks up external author email" {
+#   GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git duet -q jd fb
+#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+#   assert_success 'jane_doe@lookie.me.local'
+# }
+# 
+# @test "looks up external committer email" {
+#   GIT_DUET_EMAIL_LOOKUP_COMMAND=$GIT_DUET_TEST_LOOKUP git duet -q jd fb
+#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+#   assert_success 'fb9000@dalek.info.local'
+# }
+# 
+# @test "uses custom email template for author when provided" {
+#   local suffix=$RANDOM
+# 
+#   set_custom_email_template "{{with split .Name \" \"}}{{with index . 0}}{{toLower . }}{{end}}.{{with index . 1}}{{toLower . }}{{end}}{{end}}$suffix@mompopshop.local"
+# 
+#   git duet -q zp fb
+#   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+#   assert_success "zubaz.pants$suffix@mompopshop.local"
+# 
+#   clear_custom_email_template
+# }
+# 
+# @test "sets the git user email globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+#   assert_success 'jane@hamsters.biz.local'
+# }
+# 
+# @test "sets the git user initials globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-initials"
+#   assert_success 'jd'
+# }
+# 
+# @test "sets the git user name globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-name"
+#   assert_success 'Jane Doe'
+# }
+# 
+# @test "sets the git committer email globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
+#   assert_success 'Frances Bar'
+# }
+# 
+# @test "sets the git committer initials globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
+#   assert_success 'fb'
+# }
+# 
+# @test "sets the git committer name globally" {
+#   git duet -g -q jd fb
+#   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+#   assert_success 'f.bar@hamster.info.local'
+# }
+# 
+# @test "output is displayed" {
+#   run git duet jd fb
+#   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+#   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+# }
+# 
+# @test "output is not displayed when quieted" {
+#   run git duet -q jd fb
+#   assert_success ""
+# }
+# 
+# @test "prints current config" {
+#   git duet -q jd fb
+#   run git duet
+#   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+#   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+# }
+# 
+# @test "honors source when printing config" {
+#   git duet -q -g fb jd
+#   git solo fb
+#   run git duet
+#   assert_line "GIT_AUTHOR_NAME='Frances Bar'"
+#   assert_line "GIT_AUTHOR_EMAIL='f.bar@hamster.info.local'"
+#   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+#   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+# }


### PR DESCRIPTION
During Pivotal Cloud Foundry's Hack Day, 2015, we decided it would be cool to add on this functionality:

```
git team jd td go
```

In this instance, the first person becomes the author and the rest become combined into the committer (see the commit history of this pull request below). This feature is not fully baked yet and can stand to be refactored, but we'd (@aauthor and myself) appreciate your feedback on this feature and its implementation (as it was our first attempt at Go!).
