### PR TITLE
Git duet revert

### DIFF
--- a/src/git-duet/git-duet-commit/main.go
+++ b/src/git-duet/git-duet-commit/main.go
@@ -3,68 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
-	"git-duet"
+	"git-duet/internal/cmd"
 )
 
 func main() {
-	configuration, err := duet.NewConfiguration()
+	err := cmd.ExecuteWithSignoff("commit")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
-
-	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	author, err := gitConfig.GetAuthor()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if author == nil {
-		fmt.Println("no duet set")
-		os.Exit(1)
-	}
-
-	committer, err := gitConfig.GetCommitter()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	args := os.Args[1:]
-	if committer != nil {
-		args = append([]string{"--signoff"}, args...)
-	} else {
-		committer = author
-	}
-
-	cmd := exec.Command("git", append([]string{"commit"}, args...)...)
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("GIT_AUTHOR_NAME=%s", author.Name),
-		fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", author.Email),
-		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committer.Name),
-		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committer.Email),
-	)
-	err = cmd.Run()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if configuration.RotateAuthor {
-		if err = gitConfig.RotateAuthor(); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
 	}
 }

--- a/src/git-duet/git-duet-revert/main.go
+++ b/src/git-duet/git-duet-revert/main.go
@@ -3,68 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
-	"git-duet"
+	"git-duet/internal/cmd"
 )
 
 func main() {
-	configuration, err := duet.NewConfiguration()
+	err := cmd.ExecuteWithSignoff("revert")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
-
-	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	author, err := gitConfig.GetAuthor()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if author == nil {
-		fmt.Println("no duet set")
-		os.Exit(1)
-	}
-
-	committer, err := gitConfig.GetCommitter()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	args := os.Args[1:]
-	if committer != nil {
-		args = append([]string{"--signoff"}, args...)
-	} else {
-		committer = author
-	}
-
-	cmd := exec.Command("git", append([]string{"revert"}, args...)...)
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("GIT_AUTHOR_NAME=%s", author.Name),
-		fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", author.Email),
-		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committer.Name),
-		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committer.Email),
-	)
-	err = cmd.Run()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if configuration.RotateAuthor {
-		if err = gitConfig.RotateAuthor(); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
 	}
 }

--- a/src/git-duet/git-duet-revert/main.go
+++ b/src/git-duet/git-duet-revert/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"git-duet"
+)
+
+func main() {
+	configuration, err := duet.NewConfiguration()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	author, err := gitConfig.GetAuthor()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if author == nil {
+		fmt.Println("no duet set")
+		os.Exit(1)
+	}
+
+	committer, err := gitConfig.GetCommitter()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	args := os.Args[1:]
+	if committer != nil {
+		args = append([]string{"--signoff"}, args...)
+	} else {
+		committer = author
+	}
+
+	cmd := exec.Command("git", append([]string{"revert"}, args...)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GIT_AUTHOR_NAME=%s", author.Name),
+		fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", author.Email),
+		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committer.Name),
+		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committer.Email),
+	)
+	err = cmd.Run()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if configuration.RotateAuthor {
+		if err = gitConfig.RotateAuthor(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+}

--- a/src/git-duet/internal/cmd/cmd.go
+++ b/src/git-duet/internal/cmd/cmd.go
@@ -1,0 +1,71 @@
+// cmd houses shared command logic between git-duet commands
+//
+// This package should not be depended on and will be not be able to be
+// referenced when Go 1.5 rolls out support for internal packages to all
+// repositories
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"git-duet"
+)
+
+// ExecuteWithSignoff executes a signoff-able git command
+func ExecuteWithSignoff(subcommand string) error {
+	configuration, err := duet.NewConfiguration()
+	if err != nil {
+		return err
+	}
+
+	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+	if err != nil {
+		return err
+	}
+
+	author, err := gitConfig.GetAuthor()
+	if err != nil {
+		return err
+	}
+
+	if author == nil {
+		return err
+	}
+
+	committer, err := gitConfig.GetCommitter()
+	if err != nil {
+		return err
+	}
+
+	args := os.Args[1:]
+	if committer != nil {
+		args = append([]string{"--signoff"}, args...)
+	} else {
+		committer = author
+	}
+
+	cmd := exec.Command("git", append([]string{subcommand}, args...)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GIT_AUTHOR_NAME=%s", author.Name),
+		fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", author.Email),
+		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committer.Name),
+		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committer.Email),
+	)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	if configuration.RotateAuthor {
+		if err = gitConfig.RotateAuthor(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/git-duet-revert.bats
+++ b/test/git-duet-revert.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "lists the alpha of the duet as author in the log" {
+  git duet -q jd fb
+  git duet-revert --no-edit HEAD
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "lists the omega of the duet as committer in the log" {
+  git duet -q jd fb
+  git duet-revert --no-edit HEAD
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+}
+
+@test "does not rotate author by default" {
+  git duet -q jd fb
+
+  git duet-revert --no-edit HEAD
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+
+  git duet-revert --no-edit HEAD
+  git log -1 --format='%an <%ae>'
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+}
+
+@test "respects GIT_DUET_ROTATE_AUTHOR" {
+  git duet -q jd fb
+
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-revert --no-edit HEAD
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-revert --no-edit HEAD
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "GIT_DUET_ROTATE_AUTHOR updates the correct config" {
+  git duet -q -g jd fb
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane@hamsters.biz.local'
+
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-revert --no-edit HEAD
+  assert_success
+
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'f.bar@hamster.info.local'
+}
+
+@test "does not update mtime when rotating committer" {
+  git duet -q jd fb
+  git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-revert --no-edit HEAD
+  assert_success
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+  assert_equal 1 $status
+}
+
+@test "lists the soloist as author in the log" {
+  git solo -q jd
+  git duet-revert --no-edit HEAD
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "lists the soloist as committer in the log" {
+  git solo -q jd
+  git duet-revert --no-edit HEAD
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "does not include Signed-off-by when soloing" {
+  git solo -q jd
+  git duet-revert --no-edit HEAD
+  run grep 'Signed-off-by' .git/COMMIT_EDITMSG
+  assert_failure ''
+}
+
+@test "rejects commits with no author" {
+  run git duet-revert --no-edit HEAD
+  assert_failure
+}
+
+@test "writes mtime to config" {
+  git duet jd fb
+  git duet-revert --no-edit HEAD
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+  assert_success
+}
+
+@test "does not panic if no duet pair set" {
+  run git duet-revert --no-edit HEAD
+  assert_line "git-author not set"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -38,6 +38,9 @@ EOF
   chmod +x "$GIT_DUET_TEST_LOOKUP"
   git init -q "$GIT_DUET_TEST_REPO"
   cd "$GIT_DUET_TEST_REPO"
+  touch foo
+  git add foo
+  git commit -m 'test commit for reverting'
 }
 
 teardown() {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -40,6 +40,8 @@ EOF
   cd "$GIT_DUET_TEST_REPO"
   touch foo
   git add foo
+  git config user.name 'Test User'
+  git config user.email 'test@example.com'
   git commit -m 'test commit for reverting'
 }
 


### PR DESCRIPTION
Addresses #16 

Unfortunately `bats` doesn't have a great way to share tests currently (see https://github.com/sstephenson/bats/issues/99) so the tests are largely duplicated from `git duet-commit` aside from the hooks which don't seem to be triggered when reverting commits.
