### PR TITLE
Add `git-duet-merge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ email:
   domain: awesometown.local
 ```
 
-If you want your authors file to live somwhere else, just tell
+If you want your authors file to live somewhere else, just tell
 `git-duet` about it via the `GIT_DUET_AUTHORS_FILE` environmental
 variable, e.g.:
 
@@ -117,17 +117,24 @@ Reverting (needed to set `--signoff` and export environment variables):
 git duet-revert -v [any other git options]
 ```
 
+Merging (needed to set `--signoff` and export environment variables):
+
+``` bash
+git duet-merge -v [any other git options]
+```
+
 Suggested aliases:
 
 ```
 dci = duet-commit
 drv = duet-revert
+dmg = duet-merge
 ```
 
-**Note:** `git-duet` only sets the configuration to use via `git duet-commit`
-and `git duet-revert`. Using `git solo` (or `git duet`) will not effect the
-configured `user.name` and `user.email`.  This allows `git commit` to be used
-normally outside of `git-duet`.
+**Note:** `git-duet` only sets the configuration to use via `git duet-commit`,
+`git duet-revert`, and `git duet-merge`. Using `git solo` (or `git duet`) will
+not effect the configured `user.name` and `user.email`.  This allows
+`git commit` to be used normally outside of `git-duet`.
 
 ### Global Config Support
 

--- a/src/git-duet/git-duet-commit/main.go
+++ b/src/git-duet/git-duet-commit/main.go
@@ -5,10 +5,11 @@ import (
 	"os"
 
 	"git-duet/internal/cmd"
+	"git-duet/internal/cmdrunner"
 )
 
 func main() {
-	err := cmd.ExecuteWithSignoff("commit")
+	err := cmdrunner.Execute(cmd.NewWithSignoff("commit"))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/src/git-duet/git-duet-merge/main.go
+++ b/src/git-duet/git-duet-merge/main.go
@@ -9,7 +9,10 @@ import (
 )
 
 func main() {
-	err := cmdrunner.Execute(cmd.NewWithSignoff("revert"))
+	err := cmdrunner.Execute(
+		cmd.New("merge"),
+		cmd.NewWithSignoff("commit", "--amend", "--no-edit"))
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/src/git-duet/internal/cmd/cmd.go
+++ b/src/git-duet/internal/cmd/cmd.go
@@ -24,6 +24,8 @@ func New(subcommand string, args ...string) Command {
 	cmd := Command{}
 	cmd.Subcommand = subcommand
 
+	// If we're explicitly providing args, use them.
+	// Otherwise, we're forwarding from user input.
 	if len(args) == 0 {
 		cmd.Args = os.Args[1:]
 	} else {

--- a/src/git-duet/internal/cmd/cmd.go
+++ b/src/git-duet/internal/cmd/cmd.go
@@ -14,8 +14,33 @@ import (
 	"git-duet"
 )
 
-// ExecuteWithSignoff executes a signoff-able git command
-func ExecuteWithSignoff(subcommand string) error {
+type Command struct {
+	Signoff bool
+	Subcommand string
+	Args []string
+}
+
+func New(subcommand string, args ...string) Command {
+	cmd := Command{}
+	cmd.Subcommand = subcommand
+
+	if len(args) == 0 {
+		cmd.Args = os.Args[1:]
+	} else {
+		cmd.Args = args
+	}
+
+	return cmd
+}
+
+func NewWithSignoff(subcommand string, args ...string) Command {
+	cmd := New(subcommand, args...)
+	cmd.Signoff = true
+
+	return cmd
+}
+
+func (duetcmd Command) Execute() error {
 	configuration, err := duet.NewConfiguration()
 	if err != nil {
 		return err
@@ -40,14 +65,13 @@ func ExecuteWithSignoff(subcommand string) error {
 		return err
 	}
 
-	args := os.Args[1:]
-	if committer != nil {
-		args = append([]string{"--signoff"}, args...)
+	if committer != nil && duetcmd.Signoff {
+		duetcmd.Args = append([]string{"--signoff"}, duetcmd.Args...)
 	} else {
 		committer = author
 	}
 
-	cmd := exec.Command("git", append([]string{subcommand}, args...)...)
+	cmd := exec.Command("git", append([]string{duetcmd.Subcommand}, duetcmd.Args...)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -62,10 +86,5 @@ func ExecuteWithSignoff(subcommand string) error {
 		return err
 	}
 
-	if configuration.RotateAuthor {
-		if err = gitConfig.RotateAuthor(); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/src/git-duet/internal/cmdrunner/execute.go
+++ b/src/git-duet/internal/cmdrunner/execute.go
@@ -1,0 +1,32 @@
+package cmdrunner
+
+import (
+	"git-duet"
+	"git-duet/internal/cmd"
+)
+
+func Execute(commands ...cmd.Command) error {
+	configuration, err := duet.NewConfiguration()
+	if err != nil {
+		return err
+	}
+
+	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+	if err != nil {
+		return err
+	}
+
+	for _, command := range commands {
+		if err := command.Execute(); err != nil {
+			return err
+		}
+	}
+
+	if configuration.RotateAuthor {
+		if err = gitConfig.RotateAuthor(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/git-duet-merge.bats
+++ b/test/git-duet-merge.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "lists the alpha of the duet as author in the log" {
+  create_branch_commit
+  git duet -q jd fb
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge new_branch
+  run git log -1 --format='%an <%ae>'
+
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "lists the omega of the duet as committer in the log" {
+  create_branch_commit
+  git duet -q jd fb
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge new_branch -q
+  run git log -1 --format='%cn <%ce>'
+
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+}
+
+@test "is a merge commit" {
+  create_branch_commit
+  git duet -q jd fb
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge new_branch -q
+
+  assert_head_is_merge
+}
+
+@test "does not rotate author by default" {
+  git duet -q jd fb
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_one -q
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+
+  create_branch_commit branch_two branch_file_two
+  add_file yet_another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_two -q
+
+  git log -1 --format='%an <%ae>'
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+}
+
+@test "respects GIT_DUET_ROTATE_AUTHOR" {
+  git duet -q jd fb
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-merge branch_one -q
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+
+  create_branch_commit branch_two branch_file_two
+  add_file yet_another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-merge branch_two -q
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "GIT_DUET_ROTATE_AUTHOR updates the correct config" {
+  git duet -q -g jd fb
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'jane@hamsters.biz.local'
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-merge branch_one -q
+  assert_success
+
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
+  assert_success 'f.bar@hamster.info.local'
+}
+
+@test "does not update mtime when rotating committer" {
+  git duet -q jd fb
+  git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_ROTATE_AUTHOR=1 git duet-merge branch_one -q
+  assert_success
+
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+  assert_equal 1 $status
+}
+
+@test "lists the soloist as author in the log" {
+  git solo -q jd
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_one -q
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "lists the soloist as committer in the log" {
+  git solo -q jd
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_one -q
+
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
+@test "does not include Signed-off-by when soloing" {
+  git solo -q jd
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_one -q
+
+  run grep 'Signed-off-by' .git/COMMIT_EDITMSG
+  assert_failure ''
+}
+
+@test "rejects commits with no author" {
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+
+  run git duet-merge branch_one -q
+
+  assert_failure
+}
+
+@test "writes mtime to config" {
+  git duet jd fb
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  git duet-merge branch_one -q
+
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+  assert_success
+}
+
+@test "does not panic if no duet pair set" {
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+
+  run git duet-merge branch_one -q
+
+  assert_line "git-author not set"
+}
+
+@test "rejects commits with stale soloists with hook" {
+  # if in CI, git-duet-pre-commit will not be in the PATH
+  # exposed to git hooks
+  if [ -n "$CI" ] ; then
+    skip "cannot test commit hook on CI without sudo"
+  fi
+
+  create_branch_commit branch_one branch_file_one
+
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+
+  git solo -q jd
+  git duet-install-hook -q
+  git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+
+  run git duet-merge branch_one -q
+
+  assert_failure
+  assert_line "your git duet settings are stale"
+}
+
+@test "rejects commits with stale duetists with hook" {
+  # if in CI, git-duet-pre-commit will not be in the PATH
+  # exposed to git hooks
+  if [ -n "$CI" ] ; then
+    skip "cannot test commit hook on CI without sudo"
+  fi
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+
+  git duet -q jd fb
+  git duet-install-hook -q
+  git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"
+
+  run git duet-merge branch_one -q
+
+  assert_failure
+  assert_line "your git duet settings are stale"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -61,6 +61,29 @@ add_file() {
   fi
 }
 
+create_branch_commit() {
+  if [ $# -eq 0 ]; then
+    git checkout -b new_branch
+  else
+    git checkout -b $1
+  fi
+
+  if [ $# -lt 2 ]; then
+    add_file branch_file.txt
+  else
+    add_file $2
+  fi
+
+  git commit -q -m 'Adding a branch commit'
+  git checkout master
+}
+
+assert_head_is_merge () {
+    msha=$(git rev-list --merges HEAD~1..HEAD)
+    [ -z "$msha" ] && return 1
+    return 0
+}
+
 set_custom_email_template() {
   clear_custom_email_template
   echo "email_template: '$1'" >> "$GIT_DUET_AUTHORS_FILE"


### PR DESCRIPTION
Because merging does not support the --signoff flag, we have to do it
manually.
1. Do the merge as normal: `git merge [branch_name]`
2. Amend the merge commit by adding the signoff:
   - `git commit --amend --no-edit --signoff`

Note that this does appear a little different to the user if adding the
commit message interactively (e.g. not using `git duet-commit -m"message"`).
The "Signed-off-by" line will not appear when writing the
commit message, but is only added after entering the message.
