### PR TITLE
Support for project trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,29 @@ Set two authors (pairing):
 git duet jd fb
 ```
 
+Set two authors (pairing) and story id:
+
+``` bash
+git duet jd fb 56735
+```
+
 Set one author (soloing):
 
 ``` bash
 git solo jd
+```
+
+Set one author (soloing) and story id:
+
+``` bash
+git solo jd 56735
+```
+
+Then the configured story id will show up like this:
+
+``` bash
+git config duet.env.git-story-id
+# -> 56735
 ```
 
 Committing (needed to set `--signoff` and export environment variables):
@@ -145,6 +164,20 @@ config:
 ``` bash
 git solo -g jd
 git duet --global jd fb
+```
+
+Setting story id globally:
+
+``` bash
+git solo -g jd 56735
+git duet --global jd fb 56735
+
+```
+Then the configured story id will show up like this:
+
+``` bash
+git config --global duet.env.git-story-id
+# -> 56735
 ```
 
 If you do this habitually, you can set the `GIT_DUET_GLOBAL` environment
@@ -326,15 +359,43 @@ git commit -v
 # ... pre-commit hook fires
 ```
 
-If you want to use the default hook (as shown above), install it while
+If you'd like to regularly remind yourself to set the solo or duet
+initials, use `git duet-prepare-commit-msg` in your prepare-commit-msg hook:
+
+*(in $REPO_ROOT/.git/hooks/prepare-commit-msg)*
+
+``` bash
+#!/bin/bash
+exec git duet-prepare-commit-msg
+```
+
+The `duet-prepare-commit-msg` command will append the story id to your commit
+messages for you. This makes an easy integration with trackers as GitHub, JIRA
+and etc.
+``` bash
+git solo jb 57632
+git ci -m "Fix issue in API HTTP handler"
+```
+
+ The commit message is modified only if the story id is not presented
+in it. It has the following format:
+
+```
+Fix issue in API HTTP handler
+
+[#57632]
+```
+
+If you want to use the default hooks (as shown above), install it while
 in your repo like so:
 
 ``` bash
 git duet-install-hook
 ```
 
-Don't worry if you forgot you already had a `pre-commit` hook installed.
-The `git duet-install-hook` command will refuse to overwrite it.
+Don't worry if you forgot you already had a `pre-commit` or
+`prepare-commit-msg` hooks installed.  The `git duet-install-hook` command will
+refuse to overwrite them.
 
 ### RubyMine integration
 

--- a/src/git-duet/git-duet-install-hook/main.go
+++ b/src/git-duet/git-duet-install-hook/main.go
@@ -59,6 +59,7 @@ func main() {
 
 	hooks := []*Hook{
 		&Hook{Name: "pre-commit"},
+		&Hook{Name: "prepare-commit-msg"},
 	}
 
 	for _, hook := range hooks {

--- a/src/git-duet/git-duet-prepare-commit-msg/main.go
+++ b/src/git-duet/git-duet-prepare-commit-msg/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+
+	"git-duet"
+
+	"code.google.com/p/getopt"
+)
+
+func main() {
+	getopt.Parse()
+
+	if getopt.NArgs() == 0 {
+		exitOnErr(errors.New("The prepare-commit-msg hook has invalid arguments"))
+	}
+
+	configuration, err := duet.NewConfiguration()
+	if err != nil {
+		exitOnErr(err)
+	}
+
+	gitConfig := &duet.GitConfig{
+		Namespace: configuration.Namespace,
+	}
+
+	storyID, err := gitConfig.GetStoryID()
+	if err != nil {
+		exitOnErr(err)
+	}
+
+	if storyID == nil {
+		os.Exit(0)
+	}
+
+	msgPath := getopt.Arg(0)
+	msgFile, err := os.OpenFile(msgPath, os.O_RDWR, os.ModePerm)
+	if err != nil {
+		exitOnErr(err)
+	}
+	defer msgFile.Close()
+
+	matcher := regexp.MustCompile(fmt.Sprintf(`\[#%v\]`, storyID))
+	if matcher.MatchReader(bufio.NewReader(msgFile)) {
+		os.Exit(0)
+	}
+
+	if _, err := msgFile.Seek(0, os.SEEK_SET); err != nil {
+		exitOnErr(err)
+	}
+
+	if err = format(msgFile, storyID); err != nil {
+		exitOnErr(err)
+	}
+}
+
+func format(original *os.File, storyID *duet.StoryID) error {
+	temporary, err := ioutil.TempFile("", ".COMMIT_MSG")
+	if err != nil {
+		return err
+	}
+	defer temporary.Close()
+
+	reader := bufio.NewReader(original)
+	written := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			break
+		}
+
+		if line == "\n" && !written {
+			line = fmt.Sprintf("\n[#%v]\n\n", storyID)
+			written = true
+		}
+
+		if _, err := fmt.Fprint(temporary, line); err != nil {
+			return err
+		}
+	}
+
+	if written {
+		return replace(original, temporary)
+	}
+
+	if _, err := fmt.Fprintf(original, "\n\n[#%v]", storyID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func replace(dst *os.File, src *os.File) error {
+	if _, err := src.Seek(0, os.SEEK_SET); err != nil {
+		return err
+	}
+
+	if _, err := dst.Seek(0, os.SEEK_SET); err != nil {
+		return err
+	}
+
+	if err := dst.Truncate(0); err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func exitOnErr(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/src/git-duet/git-duet/main.go
+++ b/src/git-duet/git-duet/main.go
@@ -29,7 +29,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if getopt.NArgs() == 0 {
+	nArgs := getopt.NArgs()
+
+	if nArgs == 0 {
 		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
 		if err != nil {
 			fmt.Println(err)
@@ -63,7 +65,7 @@ func main() {
 		gitConfig.Scope = duet.Global
 	}
 
-	if getopt.NArgs() != 2 {
+	if nArgs < 2 || nArgs > 3 {
 		fmt.Println("must specify two sets of initials")
 		os.Exit(1)
 	}
@@ -90,6 +92,16 @@ func main() {
 		os.Exit(86)
 	}
 	if err = gitConfig.SetCommitter(committer); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if nArgs == 3 {
+		if err = gitConfig.SetStoryID(duet.NewStoryID(getopt.Arg(2))); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	} else if err = gitConfig.ClearStoryID(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/src/git-duet/git-solo/main.go
+++ b/src/git-duet/git-solo/main.go
@@ -29,7 +29,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if getopt.NArgs() == 0 {
+	nArgs := getopt.NArgs()
+	if nArgs == 0 {
 		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
 		if err != nil {
 			fmt.Println(err)
@@ -71,6 +72,16 @@ func main() {
 	}
 
 	if err = gitConfig.ClearCommitter(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if nArgs == 2 {
+		if err = gitConfig.SetStoryID(duet.NewStoryID(getopt.Arg(1))); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	} else if err = gitConfig.ClearStoryID(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/src/git-duet/git_config.go
+++ b/src/git-duet/git_config.go
@@ -247,8 +247,11 @@ func (gc *GitConfig) GetStoryID() (*StoryID, error) {
 		return nil, err
 	}
 
-	storyID := StoryID(id)
-	return &storyID, nil
+	if id == "" {
+		return nil, nil
+	}
+
+	return NewStoryID(id), nil
 }
 
 // GetMtime returns the last time the author/committer was written

--- a/src/git-duet/git_config.go
+++ b/src/git-duet/git_config.go
@@ -11,7 +11,22 @@ import (
 	"time"
 )
 
-type scope int
+type (
+	scope int
+	// StoryID represents a current working story id
+	StoryID string
+)
+
+// NewStoryID create a *StoryID from string
+func NewStoryID(id string) *StoryID {
+	storyID := StoryID(id)
+	return &storyID
+}
+
+// String converts the StoryID to a string
+func (id *StoryID) String() string {
+	return string(*id)
+}
 
 // Default uses the default search order and writes to the local config
 // Local reads and writes from the local git config
@@ -70,6 +85,17 @@ func (gc *GitConfig) ClearCommitter() (err error) {
 	return nil
 }
 
+// ClearStoryID removes story id from config
+func (gc *GitConfig) ClearStoryID() error {
+	if err := gc.unsetKey("git-story-id"); err != nil {
+		return err
+	}
+	if err := gc.updateMtime(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SetAuthor sets the configuration for author name and email
 func (gc *GitConfig) SetAuthor(author *Pair) (err error) {
 	if err = gc.setAuthor(author); err != nil {
@@ -87,6 +113,17 @@ func (gc *GitConfig) SetCommitter(committer *Pair) (err error) {
 		return err
 	}
 	if err = gc.updateMtime(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetStoryID sets the configuration for story id
+func (gc *GitConfig) SetStoryID(id *StoryID) error {
+	if err := gc.setStoryID(id); err != nil {
+		return err
+	}
+	if err := gc.updateMtime(); err != nil {
 		return err
 	}
 	return nil
@@ -140,6 +177,13 @@ func (gc *GitConfig) setCommitter(committer *Pair) (err error) {
 	return nil
 }
 
+func (gc *GitConfig) setStoryID(id *StoryID) (err error) {
+	if err = gc.setKey("git-story-id", string(*id)); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetAuthor returns the currently configured author (nil if none)
 func (gc *GitConfig) GetAuthor() (pair *Pair, err error) {
 	initials, err := gc.getKey("git-author-initials")
@@ -163,8 +207,8 @@ func (gc *GitConfig) GetAuthor() (pair *Pair, err error) {
 
 	return &Pair{
 		Initials: initials,
-		Name:  name,
-		Email: email,
+		Name:     name,
+		Email:    email,
 	}, nil
 }
 
@@ -191,9 +235,20 @@ func (gc *GitConfig) GetCommitter() (pair *Pair, err error) {
 
 	return &Pair{
 		Initials: initials,
-		Name:  name,
-		Email: email,
+		Name:     name,
+		Email:    email,
 	}, nil
+}
+
+// GetStoryID returns the currently configured story id (nil if none)
+func (gc *GitConfig) GetStoryID() (*StoryID, error) {
+	id, err := gc.getKey("git-story-id")
+	if err != nil {
+		return nil, err
+	}
+
+	storyID := StoryID(id)
+	return &storyID, nil
 }
 
 // GetMtime returns the last time the author/committer was written

--- a/src/git-duet/internal/cmd/cmd.go
+++ b/src/git-duet/internal/cmd/cmd.go
@@ -83,6 +83,7 @@ func (duetcmd Command) Execute() error {
 		fmt.Sprintf("GIT_COMMITTER_NAME=%s", committer.Name),
 		fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", committer.Email),
 	)
+
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/test/git-duet-install-hooks.bats
+++ b/test/git-duet-install-hooks.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-@test "writes the hook to the pre-commit hook file" {
+@test "writes the hook to thfe pre-commit hook file" {
   run git duet-install-hook -q
   assert_success
   [ -f .git/hooks/pre-commit ]
@@ -14,8 +14,26 @@ load test_helper
   [ -x .git/hooks/pre-commit ]
 }
 
-@test "does not overwrite existing file" {
+@test "does not overwrite existing pre-commit file" {
   touch .git/hooks/pre-commit
+  run git duet-install-hook -q
+  assert_failure
+}
+
+@test "writes the hook to thfe prepare-commit-msg hook file" {
+  run git duet-install-hook -q
+  assert_success
+  [ -f .git/hooks/prepare-commit-msg ]
+}
+
+@test "makes the prepare-commit-msg hook executable" {
+  run git duet-install-hook -q
+  assert_success
+  [ -x .git/hooks/prepare-commit-msg ]
+}
+
+@test "does not overwrite existing prepare-commit-msg file" {
+  touch .git/hooks/prepare-commit-msg
   run git duet-install-hook -q
   assert_failure
 }

--- a/test/git-duet-prepare-commit-msg.bats
+++ b/test/git-duet-prepare-commit-msg.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "appends the story ID to the commit message after git-solo" {
+  git duet-install-hook -q
+
+  git solo -q jd 201517
+  add_file
+  git duet-commit -q -m 'Testing formatting of commit msg for git-solo'
+
+  run git log -1 --pretty='%b'
+  assert_output '[#201517]'
+}
+
+@test "appends the story ID to the commit message after git-duet" {
+  git duet-install-hook -q
+  git duet -q jd fb 201519
+  add_file
+  git duet-commit -q -m 'Testing formatting of commit msg for git-duet'
+
+  run git log -1 --pretty='%b'
+  assert_line '[#201519]'
+}
+
+@test "does not appent the story ID to the commit message when it's already presented after git-duet" {
+  git duet-install-hook -q
+  git duet -q jd fb 201517
+  add_file
+  git duet-commit -q -m 'Testing formatting of commit msg for git-duet [#201517]'
+
+  run git log -1 --format='%s%n%b'
+  assert_line 'Testing formatting of commit msg for git-duet [#201517]'
+  assert_line 'Signed-off-by: Frances Bar <f.bar@hamster.info.local>'
+}
+
+@test "does not appent the story ID to the commit message when it's already presented after git-solo" {
+  git duet-install-hook -q
+  git solo -q jd 201517
+  add_file
+  git duet-commit -q -m 'Testing formatting of commit msg for git-solo [#201517]'
+
+  run git log -1 --format='%s%n%b'
+  assert_output 'Testing formatting of commit msg for git-solo [#201517]'
+}

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -26,6 +26,12 @@ load test_helper
   assert_success 'fb'
 }
 
+@test "sets the git story id" {
+  git duet -q jd fb 201612
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_success '201612'
+}
+
 @test "caches the git committer name" {
   git duet -q jd fb
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-name"
@@ -62,6 +68,13 @@ load test_helper
   clear_custom_email_template
 }
 
+@test "usets the story id after duet" {
+  git duet -q jd fb 201612
+  git duet -q jd fb
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_equal 1 $status
+}
+
 @test "sets the git user email globally" {
   git duet -g -q jd fb
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
@@ -96,6 +109,19 @@ load test_helper
   git duet -g -q jd fb
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
   assert_success 'f.bar@hamster.info.local'
+}
+
+@test "sets the git story id globally" {
+  git duet -g -q jd fb 201612
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_success '201612'
+}
+
+@test "usets the story id after duet" {
+  git duet -g -q jd fb 201612
+  git duet -g -q jd fb
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_equal 1 $status
 }
 
 @test "output is displayed" {

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -31,6 +31,12 @@ load test_helper
   assert_success 'jane@hamsters.biz.local'
 }
 
+@test "caches the git story id" {
+  git solo -q jd 201512
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_success '201512'
+}
+
 @test "builds email from id" {
   git solo al
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
@@ -81,6 +87,13 @@ load test_helper
   assert_equal 1 $status
 }
 
+@test "unsets git story id after duet" {
+  git duet -q jd fb 201512
+  git solo -q jd
+  run git config "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_equal 1 $status
+}
+
 @test "respects GIT_DUET_GLOBAL" {
   GIT_DUET_GLOBAL=1 git solo jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-author-email"
@@ -99,10 +112,30 @@ load test_helper
   assert_success 'Jane Doe'
 }
 
+@test "sets the git story id globally" {
+  git solo -g -q jd 201512
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_success '201512'
+}
+
 @test "unsets git committer email after duet globally" {
   git duet -g -q jd fb
   git solo -g -q jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
+  assert_equal 1 $status
+}
+
+@test "unsets git story id after duet globally" {
+  git duet -g -q jd fb 201512
+  git solo -g -q jd
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
+  assert_equal 1 $status
+}
+
+@test "unsets git story id after duet globally" {
+  git duet -g -q jd fb 201512
+  git solo -g -q jd
+  run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-story-id"
   assert_equal 1 $status
 }
 


### PR DESCRIPTION
I think that really beneficial for git-duet is to support story id as optional parameter of `git-duet` and `git-solo` commands. In addition to that `prepare-commit-msg` hook can take the responsibility to append the story id to the commit message, if it is not presented. 

The workflow can be illustrated with the following commands:

``` bash
$ git duet sr jb 57634
$ git add README.md
$ git commit -m "Add README"
$ git log head

commit 9525a55c148fd9ec3064bc79ef836594c41308fa
Author: Svett Ralchev <nospam@gmail.com>
Date:   Mon Nov 30 21:49:34 2015 +0000

    Add README.md

    [#57634]
```

If you are using trackers as JIRA or Pivotal Tracker, you can use some of their plugins to monitor such a commits and associate them with the story defined in the commit message.
