### PR TITLE
Add the ability for `git-duet` to optionally set user.name and user.email

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ drb = rebase -i --exec 'git duet-commit --amend --reset-author'
 
 **Note:** `git-duet` only sets the configuration to use via `git duet-commit`,
 `git duet-revert`, and `git duet-merge`. Using `git solo` (or `git duet`) will
-not effect the configured `user.name` and `user.email`.  This allows
-`git commit` to be used normally outside of `git-duet`.
+not effect the configured `user.name` and `user.email`.  This allows `git
+commit` to be used normally outside of `git-duet`. You can set an environment
+variable, `GIT_DUET_SET_GIT_USER_CONFIG` to `1` to override this behavior and
+set the `user.name` and `user.email` fields.
 
 Another option for `git rebase`ing with `git-duet` is to use
 [git-duet-rebase.sh](scripts/git-duet-rebase.sh) courtesy of @pivotaljohn. This

--- a/configuration.go
+++ b/configuration.go
@@ -9,12 +9,13 @@ import (
 
 // Configuration represents package configuration (shared by commands)
 type Configuration struct {
-	Namespace    string
-	PairsFile    string
-	EmailLookup  string
-	Global       bool
-	RotateAuthor bool
-	StaleCutoff  time.Duration
+	Namespace        string
+	PairsFile        string
+	EmailLookup      string
+	Global           bool
+	RotateAuthor     bool
+	SetGitUserConfig bool
+	StaleCutoff      time.Duration
 }
 
 // NewConfiguration initializes Configuration from the environment
@@ -37,6 +38,10 @@ func NewConfiguration() (config *Configuration, err error) {
 	}
 
 	if config.RotateAuthor, err = strconv.ParseBool(getenvDefault("GIT_DUET_ROTATE_AUTHOR", "0")); err != nil {
+		return nil, err
+	}
+
+	if config.SetGitUserConfig, err = strconv.ParseBool(getenvDefault("GIT_DUET_SET_GIT_USER_CONFIG", "0")); err != nil {
 		return nil, err
 	}
 

--- a/git-duet/main.go
+++ b/git-duet/main.go
@@ -29,7 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace}
+	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace, SetUserConfig: configuration.SetGitUserConfig}
 	if *global || configuration.Global {
 		gitConfig.Scope = duet.Global
 	}

--- a/git-solo/main.go
+++ b/git-solo/main.go
@@ -29,7 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace}
+	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace, SetUserConfig: configuration.SetGitUserConfig}
 	if *global || configuration.Global {
 		gitConfig.Scope = duet.Global
 	}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -46,9 +46,13 @@ func (duetcmd Command) Execute() error {
 
 	var gitConfig *duet.GitConfig
 	if configuration.Global {
-		gitConfig = &duet.GitConfig{Namespace: configuration.Namespace, Scope: duet.Global}
+		gitConfig = &duet.GitConfig{
+			Namespace:     configuration.Namespace,
+			Scope:         duet.Global,
+			SetUserConfig: configuration.SetGitUserConfig,
+		}
 	} else {
-		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace)
+		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace, configuration.SetGitUserConfig)
 		if err != nil {
 			return err
 		}

--- a/internal/cmdrunner/execute.go
+++ b/internal/cmdrunner/execute.go
@@ -14,9 +14,13 @@ func Execute(commands ...cmd.Command) error {
 
 	var gitConfig *duet.GitConfig
 	if configuration.Global {
-		gitConfig = &duet.GitConfig{Namespace: configuration.Namespace, Scope: duet.Global}
+		gitConfig = &duet.GitConfig{
+			Namespace:     configuration.Namespace,
+			Scope:         duet.Global,
+			SetUserConfig: configuration.SetGitUserConfig,
+		}
 	} else {
-		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace)
+		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace, configuration.SetGitUserConfig)
 		if err != nil {
 			return err
 		}

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -93,6 +93,21 @@ load test_helper
   assert_success 'f.bar@hamster.info.local'
 }
 
+@test "GIT_DUET_ROTATE_AUTHOR respects GIT_DUET_SET_GIT_USER_CONFIG" {
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git duet -g jd fb
+  run git config --global "user.email"
+  assert_success 'jane@hamsters.biz.local'
+
+  add_file first.txt
+  GIT_DUET_SET_GIT_USER_CONFIG=1 GIT_DUET_ROTATE_AUTHOR=1 git duet-commit -q -m 'Testing jd as author, fb as committer'
+  assert_success
+
+  run git config --global "user.name"
+  assert_success 'Frances Bar'
+  run git config --global "user.email"
+  assert_success 'f.bar@hamster.info.local'
+}
+
 @test "does not update mtime when rotating committer" {
   git duet -q jd fb
   git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"

--- a/test/git-duet-merge.bats
+++ b/test/git-duet-merge.bats
@@ -132,6 +132,24 @@ load test_helper
   assert_success 'f.bar@hamster.info.local'
 }
 
+@test "GIT_DUET_ROTATE_AUTHOR respects GIT_DUET_SET_GIT_USER_CONFIG" {
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git duet -g jd fb
+  run git config --global "user.email"
+  assert_success 'jane@hamsters.biz.local'
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_SET_GIT_USER_CONFIG=1 GIT_DUET_ROTATE_AUTHOR=1 git duet-merge branch_one -q
+  assert_success
+
+  run git config --global "user.name"
+  assert_success 'Frances Bar'
+  run git config --global "user.email"
+  assert_success 'f.bar@hamster.info.local'
+}
+
+
 @test "does not update mtime when rotating committer" {
   git duet -q jd fb
   git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"

--- a/test/git-duet-revert.bats
+++ b/test/git-duet-revert.bats
@@ -84,6 +84,20 @@ load test_helper
   assert_success 'f.bar@hamster.info.local'
 }
 
+@test "GIT_DUET_ROTATE_AUTHOR respects GIT_DUET_SET_GIT_USER_CONFIG" {
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git duet -g jd fb
+  run git config --global "user.email"
+  assert_success 'jane@hamsters.biz.local'
+
+  GIT_DUET_SET_GIT_USER_CONFIG=1 GIT_DUET_ROTATE_AUTHOR=1 git duet-revert --no-edit HEAD
+  assert_success
+
+  run git config --global "user.name"
+  assert_success 'Frances Bar'
+  run git config --global "user.email"
+  assert_success 'f.bar@hamster.info.local'
+}
+
 @test "does not update mtime when rotating committer" {
   git duet -q jd fb
   git config --unset-all "$GIT_DUET_CONFIG_NAMESPACE.mtime"

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -120,6 +120,22 @@ load test_helper
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
 
+@test "does not sets git user.name and user.email by default" {
+  git duet -q jd fb
+  run git config "user.name"
+  assert_success 'Test User'
+  run git config "user.email"
+  assert_success 'test@example.com'
+}
+
+@test "sets git user.name and user.email if GIT_DUET_SET_GIT_USER_CONFIG" {
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git duet -q jd fb
+  run git config "user.name"
+  assert_success 'Jane Doe'
+  run git config "user.email"
+  assert_success 'jane@hamsters.biz.local'
+}
+
 @test "output is displayed" {
   run git duet jd fb
   assert_line "GIT_AUTHOR_NAME='Jane Doe'"

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -114,6 +114,22 @@ load test_helper
   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
 }
 
+@test "does not sets git user.name and user.email by default" {
+  git solo -q jd
+  run git config "user.name"
+  assert_success 'Test User'
+  run git config "user.email"
+  assert_success 'test@example.com'
+}
+
+@test "sets git user.name and user.email if GIT_DUET_SET_GIT_USER_CONFIG" {
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git solo -q jd
+  run git config "user.name"
+  assert_success 'Jane Doe'
+  run git config "user.email"
+  assert_success 'jane@hamsters.biz.local'
+}
+
 @test "prints current config" {
   git solo -q al
   run git solo
@@ -123,7 +139,13 @@ load test_helper
 
 @test "prints error output when commands fail" {
   cd /tmp
+
+  run git config user.name foo
+  expected_output="$output"
+
   run git solo al
   assert_failure
-  assert_line "error: could not lock config file .git/config: No such file or directory"
+  echo "output $output"
+  echo "expected output $expected_output"
+  assert_line "$expected_output"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -5,6 +5,7 @@ setup() {
 
   unset GIT_DUET_GLOBAL
   unset GIT_DUET_ROTATE_AUTHOR
+  unset GIT_DUET_SET_GIT_USER_CONFIG
 
   export GIT_DUET_CONFIG_NAMESPACE='foo.bar'
   export GIT_DUET_AUTHORS_FILE="${GIT_DUET_TEST_DIR}/.git-authors"


### PR DESCRIPTION
When GIT_DUET_SET_GIT_USER_CONFIG is set to 1, also set `user.name` and
`user.email`. This allows commands like `git rebase` which require
an author to be set in `user.name` and `user.email` to still be able to
function.

Default to off for now, but this may change in the future.

Also update one test for error message propogation to use the message
returned by a newer version of git.

Fixes #4
