### PR TITLE
Make clear that `git-duet` acts like `git config` wrt to --global

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ git solo jd
 You can also set it to `false` to always operate on the local config, even if
 the global flag is used.
 
+**Note:** This feature behaves the same as `git config` with respect to its
+treatement `--global`. For example, even if you use `--global` it will read the
+locally set `git-duet` author and committer (if it exists), before looking at
+the global `~/.gitconfig`.
+
 ### Rotating author/committer support
 
 Sometimes while pairing you want to share the authorship love between the


### PR DESCRIPTION
To avoid confusion

@tomwhoiscontrary: I had a chance to revisit #14 and decided to err on the side
of being consistent with `git` in this matter. I did, however, add a note to the
README to hopefully avoid confusion.

I'd be open to adding _another_ environment variable like
`GIT_DUET_ONLY_GLOBAL` that augments this behavior though.

Fixes #14
