### PR TITLE
Make all commands support GIT_DUET_GLOBAL

### DIFF
--- a/git-duet/main.go
+++ b/git-duet/main.go
@@ -29,13 +29,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if getopt.NArgs() == 0 {
-		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace}
+	if *global || configuration.Global {
+		gitConfig.Scope = duet.Global
+	}
 
+	if getopt.NArgs() == 0 {
 		author, err := gitConfig.GetAuthor()
 		if err != nil {
 			fmt.Println(err)
@@ -54,13 +53,6 @@ func main() {
 		printAuthor(author)
 		printNextComitter(committers)
 		os.Exit(0)
-	}
-
-	gitConfig := &duet.GitConfig{
-		Namespace: configuration.Namespace,
-	}
-	if configuration.Global || *global {
-		gitConfig.Scope = duet.Global
 	}
 
 	if getopt.NArgs() < 2 {
@@ -96,7 +88,7 @@ func main() {
 		committers = append(committers, committer)
 	}
 
-	if err = gitConfig.SetCommitters(committers); err != nil {
+	if err = gitConfig.SetCommitters(committers...); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/git-solo/main.go
+++ b/git-solo/main.go
@@ -29,13 +29,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if getopt.NArgs() == 0 {
-		gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	gitConfig := &duet.GitConfig{Namespace: configuration.Namespace}
+	if *global || configuration.Global {
+		gitConfig.Scope = duet.Global
+	}
 
+	if getopt.NArgs() == 0 {
 		author, err := gitConfig.GetAuthor()
 		if err != nil {
 			fmt.Println(err)
@@ -44,13 +43,6 @@ func main() {
 
 		printAuthor(author)
 		os.Exit(0)
-	}
-
-	gitConfig := &duet.GitConfig{
-		Namespace: configuration.Namespace,
-	}
-	if configuration.Global || *global {
-		gitConfig.Scope = duet.Global
 	}
 
 	pairs, err := duet.NewPairsFromFile(configuration.PairsFile, configuration.EmailLookup)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -44,9 +44,19 @@ func (duetcmd Command) Execute() error {
 		return err
 	}
 
-	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
+	var gitConfig *duet.GitConfig
+	if configuration.Global {
+		gitConfig = &duet.GitConfig{Namespace: configuration.Namespace, Scope: duet.Global}
+	} else {
+		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace)
+		if err != nil {
+			return err
+		}
+	}
+
 	if err != nil {
-		return err
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	author, err := gitConfig.GetAuthor()

--- a/internal/cmdrunner/execute.go
+++ b/internal/cmdrunner/execute.go
@@ -12,9 +12,14 @@ func Execute(commands ...cmd.Command) error {
 		return err
 	}
 
-	gitConfig, err := duet.GetAuthorConfig(configuration.Namespace)
-	if err != nil {
-		return err
+	var gitConfig *duet.GitConfig
+	if configuration.Global {
+		gitConfig = &duet.GitConfig{Namespace: configuration.Namespace, Scope: duet.Global}
+	} else {
+		gitConfig, err = duet.GetAuthorConfig(configuration.Namespace)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, command := range commands {
@@ -24,7 +29,7 @@ func Execute(commands ...cmd.Command) error {
 	}
 
 	if configuration.RotateAuthor {
-		if err = gitConfig.RotateAuthor(); err != nil {
+		if err := gitConfig.RotateAuthor(); err != nil {
 			return err
 		}
 	}

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -103,6 +103,20 @@ load test_helper
   assert_equal 1 $status
 }
 
+@test "respects GIT_DUET_GLOBAL" {
+  git duet -q -g zs jd
+  git duet -q jd fb
+
+  add_file first.txt
+  GIT_DUET_GLOBAL=1 git duet-commit -q -m 'Testing jd as author, fb as committer'
+  assert_success
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Zubaz Shirts <z.shirts@pika.info.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
 @test "lists the soloist as author in the log" {
   git solo -q jd
   add_file

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -108,7 +108,7 @@ load test_helper
   git duet -q jd fb
 
   add_file first.txt
-  GIT_DUET_GLOBAL=1 git duet-commit -q -m 'Testing jd as author, fb as committer'
+  GIT_DUET_GLOBAL=1 git duet-commit -q -m 'Testing zs as author, jd as committer'
   assert_success
 
   run git log -1 --format='%an <%ae>'

--- a/test/git-duet-merge.bats
+++ b/test/git-duet-merge.bats
@@ -146,6 +146,22 @@ load test_helper
   assert_equal 1 $status
 }
 
+@test "respects GIT_DUET_GLOBAL" {
+  git duet -q -g zs jd
+  git duet -q fb on
+
+  create_branch_commit branch_one branch_file_one
+  add_file another_commit.txt
+  git commit -q -m 'Avoid fast-forward'
+  GIT_DUET_GLOBAL=1 git duet-merge branch_one -q
+  assert_success
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Zubaz Shirts <z.shirts@pika.info.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
 @test "lists the soloist as author in the log" {
   git solo -q jd
 

--- a/test/git-duet-revert.bats
+++ b/test/git-duet-revert.bats
@@ -93,6 +93,19 @@ load test_helper
   assert_equal 1 $status
 }
 
+@test "respects GIT_DUET_GLOBAL" {
+  git duet -q -g zs jd
+  git duet -q jd fb
+
+  GIT_DUET_GLOBAL=1 git duet-revert --no-edit HEAD
+  assert_success
+
+  run git log -1 --format='%an <%ae>'
+  assert_success 'Zubaz Shirts <z.shirts@pika.info.local>'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Jane Doe <jane@hamsters.biz.local>'
+}
+
 @test "lists the soloist as author in the log" {
   git solo -q jd
   git duet-revert --no-edit HEAD

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -109,6 +109,17 @@ load test_helper
   assert_success 'f.bar@hamster.info.local'
 }
 
+@test "reads configuration globally" {
+  git duet -g -q jd fb
+  git duet fb on
+  run git duet -g
+  assert_success
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+}
+
 @test "output is displayed" {
   run git duet jd fb
   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
@@ -132,7 +143,7 @@ load test_helper
 }
 
 @test "honors source when printing config" {
-  git duet -q -g fb jd
+  git duet -q -g on jd
   git solo fb
   run git duet
   assert_line "GIT_AUTHOR_NAME='Frances Bar'"

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -71,14 +71,14 @@ load test_helper
   git duet -q jd fb
   git solo -q jd
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
-  assert_equal 1 $status
+  assert_success ""
 }
 
 @test "unsets git committer initials after duet" {
   git duet -q jd fb
   git solo -q jd
   run git config "$GIT_DUET_CONFIG_NAMESPACE.git-committer-initials"
-  assert_equal 1 $status
+  assert_success ""
 }
 
 @test "respects GIT_DUET_GLOBAL" {
@@ -103,7 +103,15 @@ load test_helper
   git duet -g -q jd fb
   git solo -g -q jd
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
-  assert_equal 1 $status
+  assert_success ""
+}
+@test "reads configuration globally" {
+  git solo -g -q jd
+  git solo fb
+  run git duet -g
+  assert_success
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
 }
 
 @test "prints current config" {


### PR DESCRIPTION
This does the following:
- Make `git solo` and `git duet` with no initials respect `-g` and
  `GIT_DUET_GLOBAL` when displaying configuration
- Make `git duet-(merge|revert|commit)` respect `GIT_DUET_GLOBAL`. If
  `GIT_DUET_GLOBAL` is set, they will ignore any repo level git-duet
  configuration.

Instead of unsetting keys for the committers when running `git solo`,
set them to empty string to avoid falling through to the global git
config when reading configuration (i.e. if the author was set locally,
but no committer it would fall back to the global committer which is
probably not desirable).

Fixes #14
