### PR TITLE
Add top level .git-authors configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@
 
 ## Building
 
-Requires Go 1.5 (using `GOVENDOREXPERIMENT=1`).
+Requires Go 1.7
 
 Using [`gvt`](https://github.com/FiloSottile/gvt) to manage dependencies.
 
 To run tests locally:
 
-0. `GOVENDOREXPERIMENT=1 go test ./...`
 0. Install [`bats`](https://github.com/sstephenson/bats.git)
-0. `GOVENDOREXPERIMENT=1 go install ./...` (make sure the artifacts end up in your `$PATH`)
-0. `bats test`
+0. `./scripts/build`
+0. `./scripts/install`
+0. `./scripts/test`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Options:
 
 Make an authors file with email domain, or if you're already using
 [git pair](https://github.com/pivotal/git_scripts), just symlink your
-`~/.pairs` file over to `~/.git-authors`.
+`~/.pairs` file over to `~/.git-authors`. You can also set a repository
+specific authors file by placing a `.git-authors` file at the root
+of your `git` repository.
 
 ``` yaml
 authors:

--- a/configuration.go
+++ b/configuration.go
@@ -2,8 +2,10 @@ package duet
 
 import (
 	"os"
+	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -24,8 +26,11 @@ type Configuration struct {
 func NewConfiguration() (config *Configuration, err error) {
 	config = &Configuration{
 		Namespace:   getenvDefault("GIT_DUET_CONFIG_NAMESPACE", "duet.env"),
-		PairsFile:   getenvDefault("GIT_DUET_AUTHORS_FILE", path.Join(os.Getenv("HOME"), ".git-authors")),
 		EmailLookup: os.Getenv("GIT_DUET_EMAIL_LOOKUP_COMMAND"),
+	}
+
+	if config.PairsFile, err = getPairsFile(); err != nil {
+		return nil, err
 	}
 
 	cutoff, err := strconv.Atoi(getenvDefault("'GIT_DUET_SECONDS_AGO_STALE'", "1200"))
@@ -48,6 +53,27 @@ func NewConfiguration() (config *Configuration, err error) {
 	config.StaleCutoff = time.Duration(cutoff) * time.Second
 
 	return config, nil
+}
+
+func getPairsFile() (value string, err error) {
+
+	authorsFile := ".git-authors"
+
+	if os.Getenv("GIT_DUET_AUTHORS_FILE") != "" {
+		return os.Getenv("GIT_DUET_AUTHORS_FILE"), nil
+	}
+
+	gitDirectory, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+
+	gitDirectoryAuthors := path.Join(strings.TrimSpace(string(gitDirectory)), authorsFile)
+	if _, err := os.Stat(gitDirectoryAuthors); err == nil {
+		return gitDirectoryAuthors, nil
+	}
+
+	return path.Join(os.Getenv("HOME"), authorsFile), nil
 }
 
 func getenvDefault(key, defaultValue string) (value string) {

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -174,3 +174,17 @@ load test_helper
   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
+
+@test "respects git root level .git-authors configuration" {
+  setup_root_git_author
+  mkdir new_dir
+  cd new_dir
+
+  git duet -q dj fc
+  run git duet
+
+  assert_line "GIT_AUTHOR_NAME='Dane Joe'"
+  assert_line "GIT_AUTHOR_EMAIL='dane@bananas.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Car'"
+  assert_line "GIT_COMMITTER_EMAIL='f.car@banana.info.local'"
+}

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -112,6 +112,7 @@ load test_helper
   run git config --global "$GIT_DUET_CONFIG_NAMESPACE.git-committer-email"
   assert_success ""
 }
+
 @test "reads configuration globally" {
   git solo -g -q jd
   git solo fb
@@ -155,4 +156,14 @@ load test_helper
   echo "output $output"
   echo "expected output $expected_output"
   assert_line "$expected_output"
+}
+
+@test "respects git root level .git-authors configuration" {
+  setup_root_git_author
+
+  GIT_DUET_SET_GIT_USER_CONFIG=1 git solo -q fc
+  run git config "user.name"
+  assert_success 'Frances Car'
+  run git config "user.email"
+  assert_success 'f.car@banana.info.local'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -81,6 +81,25 @@ create_branch_commit() {
   git checkout master
 }
 
+setup_root_git_author() {
+  unset GIT_DUET_AUTHORS_FILE
+  cat > ".git-authors" <<EOF
+---
+authors:
+  dj: Dane Joe
+  fc: Frances Car
+
+email:
+  domain: banana.info.local
+
+email_addresses:
+  dj: dane@bananas.biz.local
+  fc: f.car@banana.info.local
+EOF
+  mkdir new_dir
+  cd new_dir
+}
+
 assert_head_is_merge () {
     msha=$(git rev-list --merges HEAD~1..HEAD)
     [ -z "$msha" ] && return 1

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -96,8 +96,6 @@ email_addresses:
   dj: dane@bananas.biz.local
   fc: f.car@banana.info.local
 EOF
-  mkdir new_dir
-  cd new_dir
 }
 
 assert_head_is_merge () {


### PR DESCRIPTION
Adding support for https://github.com/git-duet/git-duet/issues/45

This assumes that each git repository could have a top level `.git-authors` file. This does not support a single repository with multiple `.git-authors` files.

Added some tests and ran the tests. I also updated `CONTRIBUTING.md` with what seemed to work best for me while developing locally.