### PR TITLE
Fix RubyMine wrapper script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ executions of `git commit`.  Such an executable is available in the Git
 Duet repository, and may be installed somewhere in your `$PATH` like so:
 
 ``` bash
-\curl -Ls -o ~/scripts/rubymine-git-wrapper https://raw.github.com/git-duet/git-duet/master/scripts/rubymine-git-wrapper
+curl -Ls -o ~/bin/rubymine-git-wrapper https://raw.github.com/git-duet/git-duet/master/scripts/rubymine-git-wrapper
 chmod +x ~/bin/rubymine-git-wrapper
 ```
 

--- a/scripts/rubymine-git-wrapper
+++ b/scripts/rubymine-git-wrapper
@@ -1,8 +1,2 @@
 #!/usr/bin/env bash
-
-if [[ "$1" == commit ]] ; then
-  shift
-  exec git duet-commit "$@"
-fi
-
-exec git "$@"
+exec git "${@/%commit/duet-commit}"


### PR DESCRIPTION

- `commit` is no longer the first argument in the RubyMine git integration. This script
  should protect against RubyMine changing the arguments in the future
- Fix README usage example to be consistent (curl the script down to the same place we
  use it from)
