### PR TITLE
Return correct error when config is Global and git-author not set

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -69,7 +70,7 @@ func (duetcmd Command) Execute() error {
 	}
 
 	if author == nil {
-		return err
+		return errors.New("git-author not set")
 	}
 
 	committers, err := gitConfig.GetCommitters()


### PR DESCRIPTION
This is related to issue #47, in which git-duet commands fail silently when there is no git-author set. This condition arises when the Global configuration is set.

Signed-off-by: Sasha Heinen <sheinen@pivotal.io>