### PR TITLE
Rebase changes only the committer, not the author

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Merging (needed to set `--signoff` and export environment variables):
 git duet-merge -v [any other git options]
 ```
 
-Rebasing (resets the author/committer to the current pair):
+Rebasing (resets the committer to the committer of the current pair):
 
 ```bash
-git rebase -i --exec 'git duet-commit --amend --reset-author'
+git rebase -i --exec 'git duet-commit --amend'
 ```
 
 Suggested aliases:
@@ -137,7 +137,7 @@ Suggested aliases:
 dci = duet-commit
 drv = duet-revert
 dmg = duet-merge
-drb = rebase -i --exec 'git duet-commit --amend --reset-author'
+drb = rebase -i --exec 'git duet-commit --amend'
 ```
 
 **Note:** `git-duet` only sets the configuration to use via `git duet-commit`,


### PR DESCRIPTION
A normal `git rebase` keeps the author field and changes the committer to the person applying the rebase. That's the correct behaviour since the commit is still written by the original author and [the committer is the person who last applied the work](https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History).

However, the default mode of git-duet rebase is to change the author to the author of the current pair. This pull request is a follow-up to #52 making sure that the default mode is to respect the author and to only change the committer:

`git rebase -i --exec 'git duet-commit --amend'`

Executing `git duet-commit --amend` in the above command implicitly sets the `--signoff` option which will change the committer to the current pair's committer.
Note that the current pair's author is nowhere mentioned in the rebase since no code gets actually changed (...unless there are conflicts during the rebase).