### PR TITLE
correct typo preventing stale settings being observed

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -34,7 +34,7 @@ func NewConfiguration() (config *Configuration, err error) {
 		return nil, err
 	}
 
-	cutoff, err := strconv.Atoi(getenvDefault("'GIT_DUET_SECONDS_AGO_STALE'", "1200"))
+	cutoff, err := strconv.Atoi(getenvDefault("GIT_DUET_SECONDS_AGO_STALE", "1200"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was a typo that was preventing the `GIT_DUET_SECONDS_AGO_STALE` environment variable from being observed: this pull request fixes that.

Signed-off-by: Daniel Jones <daniel.jones@engineerbetter.com>