### PR TITLE
Fix error when running git-(solo|duet) outside of a git repo

### DIFF
--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -192,10 +192,27 @@ load test_helper
   git duet -q dj fc
   run git duet
 
+  assert_success
   assert_line "GIT_AUTHOR_NAME='Dane Joe'"
   assert_line "GIT_AUTHOR_EMAIL='dane@bananas.biz.local'"
   assert_line "GIT_COMMITTER_NAME='Frances Car'"
   assert_line "GIT_COMMITTER_EMAIL='f.car@banana.info.local'"
+}
+
+@test "does not error when run outside of a git repository" {
+  run git duet -g jd fb
+  assert_success
+
+  mkdir ${GIT_DUET_TEST_DIR}/no-repo
+  cd ${GIT_DUET_TEST_DIR}/no-repo
+
+  unset GIT_DUET_AUTHORS_FILE
+  run git duet
+  assert_success
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
 
 @test "installs prepare-commit-msg hook file if GIT_DUET_CO_AUTHORED_BY" {

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -177,6 +177,21 @@ load test_helper
   assert_success 'f.car@banana.info.local'
 }
 
+@test "does not error when run outside of a git repository" {
+  run git solo -g jd
+  assert_success
+
+  mkdir ${GIT_DUET_TEST_DIR}/no-repo
+  cd ${GIT_DUET_TEST_DIR}/no-repo
+
+  unset GIT_DUET_AUTHORS_FILE
+  git solo
+  run git solo
+  assert_success
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+}
+
 @test "does not write Co-authored-by trailer if GIT_DUET_CO_AUTHORED_BY is set" {
   GIT_DUET_CO_AUTHORED_BY=1 git solo -q jd
   add_file first.txt


### PR DESCRIPTION
Should fallback to using the default .git-authors location.

This bug was introduced by f3406f6dd262584d0fc89d9843be6f93e48f8a3f which added the ability to read from a repository level `.git-authors` file which inadvertently introduced a requirement that git-duet and git-solo be run from within a git repository when GIT_DUET_AUTHORS_FILE is not set. This should not be required when manipulating or reading globally set `git-duet` configuration.

`git` does not have a documented exit code for this error case (it just uses its catch-all `128`). I was on the fence between just falling back to the default when any error occurs or parsing stderr to avoid silently ignoring other errors.

Fixes #61