### PR TITLE
Return better error message when authors file is invalid YAML

### DIFF
--- a/pairs.go
+++ b/pairs.go
@@ -63,7 +63,7 @@ func NewPairsFromFile(filename string, emailLookup string) (a *Pairs, err error)
 
 	err = yaml.Unmarshal(contents, &af)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not parse %s: %+v", filename, err)
 	}
 
 	return &Pairs{


### PR DESCRIPTION
Display filepath to user.

YAML parse errors now look like:

`could not parse /home/jesse/.git-authors: yaml: line 2: mapping values are not allowed in this context`

Fixes #71 