### PR TITLE
Fix instruction order on "Co-authored-by" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ to `$HOME/.git-template`.
 so that `git duet` and `git solo` set the author for normal git commands.
 
 The common workflow is as follows:
-- run `git duet` (which will install the prepare-commit-msg hook)
 - if you have `GIT_DUET_GLOBAL` set, run `git init` once in existing repos
 so that the hook file gets copied from the `init.templatedir`
+- run `git duet` (which will install the prepare-commit-msg hook)
 - thereafter, use the normal git commands (i.e. `git commit`, `git merge` rather than
 the git-duet-subcommands `git duet-commit`, `git duet-merge`)
 - the prepare-commit-msg hook will append a `Co-authored-by` trailer for each co-author


### PR DESCRIPTION
I might be wrong, but I think the order needs to be changed. In my mac it only worked after running `git init` and then `git duet`. It might be related to the hook file.
May I suggest a diagram/state-machine on how the whole thing works? Thanks!