### PR TITLE
Reset original global git config after tests

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -7,6 +7,8 @@ setup() {
   unset GIT_DUET_ROTATE_AUTHOR
   unset GIT_DUET_SET_GIT_USER_CONFIG
   unset GIT_DUET_CO_AUTHORED_BY
+  export TEMPLATE_DIR_BAK=$(git config --global init.templateDir)
+  export HOOKS_PATH_BAK=$(git config --global core.hooksPath)
   git config --global --unset init.templateDir || true
   git config --global --unset core.hooksPath || true
 
@@ -55,6 +57,16 @@ EOF
 teardown() {
   git config --global --remove-section $GIT_DUET_CONFIG_NAMESPACE || true
   git config --global --unset init.templateDir || true
+
+  #Reset original git global config. Otherwise tests would potentially change the system config.
+  if [[ -n "$HOOKS_PATH_BAK" ]]; then
+    git config --global core.hooksPath "$HOOKS_PATH_BAK"
+  fi
+
+  if [[ -n "$TEMPLATE_DIR_BAK" ]]; then
+    git config --global init.templateDir "$TEMPLATE_DIR_BAK"
+  fi
+
   rm -rf "$GIT_DUET_TEST_DIR"
 }
 


### PR DESCRIPTION
If a contributor running the bats tests locally
had a global git config for `init.templateDir` or
`core.hooksPath`, the values would be cleared
by the tests.

Co-authored-by: David Ansari <david.ansari@sap.com>

It would be cool to see the new Co-authored-by rotation feature in a release :)