### PR TITLE
Add script to run the tests within a docker container

### DIFF
--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,0 +1,6 @@
+FROM golang:latest
+
+RUN apt update && apt install -y git bats
+ADD . /go/src/github.com/git-duet/git-duet
+WORKDIR /go/src/github.com/git-duet/git-duet
+RUN ./scripts/install

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+docker build -t test-git-duet -f Dockerfile-tests "$SCRIPT_DIR"/.. && docker run --rm test-git-duet ./scripts/test

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -37,12 +37,9 @@ email_addresses:
 EOF
 
   cat > "$GIT_DUET_TEST_LOOKUP" <<EOF
-#!/usr/bin/env ruby
-addr = {
-  'jd' => 'jane_doe@lookie.me.local',
-  'fb' => 'fb9000@dalek.info.local'
-}[ARGV.first]
-puts addr
+#!/usr/bin/env bash
+echo "jd: jane_doe@lookie.me.local
+fb: fb9000@dalek.info.local" | grep \$1 | sed 's/[a-z]\\{2\\}: \\(.*\\)/\\1/'
 EOF
   chmod +x "$GIT_DUET_TEST_LOOKUP"
   git init -q "$GIT_DUET_TEST_REPO"


### PR DESCRIPTION
Hi there 👋

I want to contribute to git-duet. But I already have git duet installed on my machine through my favourite package manager. Also, I might pull this code on several machines I do not own, that all have git-duet installed. So rather than fiddling with my PATH/GOPATH every time, I made a minimal container for running the tests. If you think that's reasonable, I could probably also update the CONTRIBUTING.md file to explain how to run the tests with docker if users want to.

In the process of doing that, I realised the tests required Ruby for looking up a user by initials in a list of users. I've migrated this to bash, to avoid pulling Ruby in that container.