### PR TITLE
Fix #74 - Display helpful message when duet-install-hook because of existing hook

### DIFF
--- a/git-duet-install-hook/main.go
+++ b/git-duet-install-hook/main.go
@@ -17,16 +17,10 @@ import (
 const preCommit = "pre-commit"
 const prepareCommitMsg = "prepare-commit-msg"
 const postCommit = "post-commit"
-
-const preCommitHook = `#!/usr/bin/env bash
-exec git duet-pre-commit "$@"
-`
-const prepareCommitMsgHook = `#!/usr/bin/env bash
-exec git duet-prepare-commit-msg "$@"
-`
-const postCommitHook = `#!/usr/bin/env bash
-exec git duet-post-commit "$@"
-`
+const sheBangBash = "#!/usr/bin/env bash\n"
+const preCommitHook = `exec git duet-pre-commit "$@"`
+const prepareCommitMsgHook = `exec git duet-prepare-commit-msg "$@"`
+const postCommitHook = `exec git duet-post-commit "$@"`
 
 func main() {
 	var (
@@ -114,16 +108,16 @@ func main() {
 
 	contents := strings.TrimSpace(string(b))
 	if contents != "" {
-		if hook == preCommitHook && contents != strings.TrimSpace(preCommitHook) ||
-			hook == prepareCommitMsgHook && contents != strings.TrimSpace(prepareCommitMsgHook) ||
-			hook == postCommitHook && contents != strings.TrimSpace(postCommitHook) {
+		if hook == preCommitHook && !strings.Contains(contents, preCommitHook) ||
+			hook == prepareCommitMsgHook && !strings.Contains(contents, prepareCommitMsgHook) ||
+			hook == postCommitHook && !strings.Contains(contents, postCommitHook) {
 			fmt.Printf("can't install hook: file %s already exists\n", hookPath)
 			os.Exit(1)
 		}
 		os.Exit(0) // hook file with the desired content already exists
 	}
 
-	if _, err = hookFile.WriteString(hook); err != nil {
+	if _, err = hookFile.WriteString(sheBangBash + hook); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/git-duet-install-hook/main.go
+++ b/git-duet-install-hook/main.go
@@ -111,7 +111,12 @@ func main() {
 		if hook == preCommitHook && !strings.Contains(contents, preCommitHook) ||
 			hook == prepareCommitMsgHook && !strings.Contains(contents, prepareCommitMsgHook) ||
 			hook == postCommitHook && !strings.Contains(contents, postCommitHook) {
-			fmt.Printf("can't install hook: file %s already exists\n", hookPath)
+			fmt.Printf(`It seems you already have a "%s" hook.
+To enable the git-duet hook, please append:
+
+  %s
+
+to your %s file.`, hookFileName, hook, hookPath)
 			os.Exit(1)
 		}
 		os.Exit(0) // hook file with the desired content already exists

--- a/scripts/test
+++ b/scripts/test
@@ -3,6 +3,8 @@
 set -o errexit
 set -o nounset
 
+ARGS=${@:-test}
+
 go vet $(go list ./... | grep -v '/vendor/')
 go test $(go list ./... | grep -v '/vendor/')
-bats -t test
+bats -t $ARGS

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-docker build -t test-git-duet -f Dockerfile-tests "$SCRIPT_DIR"/.. && docker run --rm test-git-duet ./scripts/test
+docker build -t test-git-duet -f Dockerfile-tests "$SCRIPT_DIR"/.. && docker run --rm test-git-duet ./scripts/test "$@"

--- a/test/git-duet-install-hooks.bats
+++ b/test/git-duet-install-hooks.bats
@@ -25,15 +25,51 @@ load test_helper
   [ -x .git/hooks/pre-commit ]
 }
 
+@test "does not overwrite existing pre-commit hook file with other contents" {
+  echo "Some content" > .git/hooks/pre-commit
+  local EXPECTED_HELP_MESSAGE=$(cat << EOM
+It seems you already have a "pre-commit" hook.
+To enable the git-duet hook, please append:
+
+  exec git duet-pre-commit "\$@"
+
+to your $PWD/.git/hooks/pre-commit file.
+EOM
+)
+  run git duet-install-hook -q pre-commit
+  assert_output "$EXPECTED_HELP_MESSAGE"
+  assert_failure
+}
+
 @test "does not overwrite existing prepare-commit-msg hook file with other contents" {
   echo "Some content" > .git/hooks/prepare-commit-msg
+  local EXPECTED_HELP_MESSAGE=$(cat << EOM
+It seems you already have a "prepare-commit-msg" hook.
+To enable the git-duet hook, please append:
+
+  exec git duet-prepare-commit-msg "\$@"
+
+to your $PWD/.git/hooks/prepare-commit-msg file.
+EOM
+)
   run git duet-install-hook -q prepare-commit-msg
+  assert_output "$EXPECTED_HELP_MESSAGE"
   assert_failure
 }
 
 @test "does not overwrite existing post-commit hook file with other contents" {
   echo "Some content" > .git/hooks/post-commit
+  local EXPECTED_HELP_MESSAGE=$(cat << EOM
+It seems you already have a "post-commit" hook.
+To enable the git-duet hook, please append:
+
+  exec git duet-post-commit "\$@"
+
+to your $PWD/.git/hooks/post-commit file.
+EOM
+)
   run git duet-install-hook -q post-commit
+  assert_output "$EXPECTED_HELP_MESSAGE"
   assert_failure
 }
 

--- a/test/git-duet-install-hooks.bats
+++ b/test/git-duet-install-hooks.bats
@@ -37,6 +37,27 @@ load test_helper
   assert_failure
 }
 
+@test "does not fail when pre-commit-msg contains the correct command" {
+  echo "Some content" > .git/hooks/pre-commit
+  echo 'exec git duet-pre-commit "$@"' >> .git/hooks/pre-commit
+  run git duet-install-hook -q pre-commit
+  assert_success
+}
+
+@test "does not fail when prepare-commit-msg contains the correct command" {
+  echo "Some content" > .git/hooks/prepare-commit-msg
+  echo 'exec git duet-prepare-commit-msg "$@"' >> .git/hooks/prepare-commit-msg
+  run git duet-install-hook -q prepare-commit-msg
+  assert_success
+}
+
+@test "does not fail when post-commit-msg contains the correct command" {
+  echo "Some content" > .git/hooks/post-commit
+  echo 'exec git duet-post-commit "$@"' >> .git/hooks/post-commit
+  run git duet-install-hook -q post-commit
+  assert_success
+}
+
 @test "overwrites existing prepare-commit-msg hook file with empty contents" {
   touch .git/hooks/prepare-commit-msg
   run git duet-install-hook -q prepare-commit-msg


### PR DESCRIPTION
Fixes #74 

When duet-install-hook fails because a gook already exists, we now display a helpful message, e.g. for pre-commit:

```
It seems you already have a "pre-commit" hook.
To enable the git-duet hook, please append:
  
  exec git duet-pre-commit "$@

to your .git/hooks/pre-commit file.
```

As part of this PR, I also updated the "test" script to be able specify which test file you want to run. If no args are specified, the full "test" directory is run.