### PR TITLE
test: update dockerfile to use latest git version from git-core PPA

### DIFF
--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,6 +1,6 @@
 FROM golang:latest
 
-RUN apt update && apt install -y git bats
+RUN apt update && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && apt install -y git bats software-properties-common && add-apt-repository ppa:git-core/ppa -y && apt update && apt install git -y
 ADD . /go/src/github.com/git-duet/git-duet
 WORKDIR /go/src/github.com/git-duet/git-duet
 RUN ./scripts/install

--- a/test/git-as.bats
+++ b/test/git-as.bats
@@ -486,6 +486,7 @@ load test_helper
 }
 
 @test "as duet: does not write Co-authored-by trailer when rebasing if GIT_DUET_CO_AUTHORED_BY" {
+  git config rebase.backend apply
   add_file first.txt
   git commit -q -m 'I get rebased'
   GIT_DUET_CO_AUTHORED_BY=1 git as -q jd fb

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -284,6 +284,7 @@ load test_helper
 }
 
 @test "does not write Co-authored-by trailer when rebasing if GIT_DUET_CO_AUTHORED_BY" {
+  git config rebase.backend apply
   add_file first.txt
   git commit -q -m 'I get rebased'
   GIT_DUET_CO_AUTHORED_BY=1 git duet -q jd fb

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,6 +9,7 @@ setup() {
   unset GIT_DUET_CO_AUTHORED_BY
   export TEMPLATE_DIR_BAK=$(git config --global init.templateDir)
   export HOOKS_PATH_BAK=$(git config --global core.hooksPath)
+  export REBASE_BACKEND_BAK=$(git config rebase.backend)
   git config --global --unset init.templateDir || true
   git config --global --unset core.hooksPath || true
 
@@ -62,6 +63,12 @@ teardown() {
 
   if [[ -n "$TEMPLATE_DIR_BAK" ]]; then
     git config --global init.templateDir "$TEMPLATE_DIR_BAK"
+  fi
+
+  if [[ -n "$REBASE_BACKEND_BAK" ]]; then
+    git config rebase.backend "$REBASE_BACKEND_BAK"
+  else
+    git config --unset rebase.backend
   fi
 
   rm -rf "$GIT_DUET_TEST_DIR"


### PR DESCRIPTION
This PR updates the Dockerfile to use the latest version of git that is available on `git-core` PPA. As discussed in https://github.com/git-duet/git-duet/issues/92, we will set the git config `rebase.backend` to `apply` in the failing tests cases for the meantime (follow up PRs can be raised to address this issue directly). 