### PR TITLE
Remove darwin/386 from release artifacts

### DIFF
--- a/scripts/dist
+++ b/scripts/dist
@@ -6,6 +6,6 @@ set -o nounset
 VERSION="$(git describe --tags --always --dirty)"
 LDFLAGS="-X main.VersionString=$VERSION -X main.RevisionString=$(git rev-parse --sq HEAD)"
 
-gox -ldflags "$LDFLAGS" -os 'linux windows darwin' -arch '386 amd64' -output 'dist/{{.OS}}_{{.Arch}}/{{.Dir}}' $(go list ./... | grep -v '/vendor/')
+gox -ldflags "$LDFLAGS" -osarch 'linux/386 linux/amd64 windows/386 windows/amd64 darwin/amd64' -output 'dist/{{.OS}}_{{.Arch}}/{{.Dir}}' $(go list ./... | grep -v '/vendor/')
 
 find dist/* -type d -exec tar cvzf {}.tar.gz -C {} . \;


### PR DESCRIPTION
Support for this platfrom/arch was removed in Go 1.15

Signed-off-by: Jesse Szwedko <jesse.szwedko@gmail.com>
