### PR TITLE
Use `go install` to install binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Options:
 
 1. See releases page for binary downloads, place in your `$PATH`.
 1. Install using Homebrew from the [git-duet homebrew tap](https://github.com/git-duet/homebrew-tap) (`brew install git-duet/tap/git-duet`)
-1. Build from source: `GOVENDOREXPERIMENT=1 go get github.com/git-duet/git-duet/...`
+1. Build from source: `go install github.com/git-duet/git-duet/...@latest`.
+   This will put the binaries in `$GOBIN`, if set, or `$GOPATH/bin` (see `go
+   help install` for more details).
 
 ## Usage
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -3,6 +3,5 @@
 set -o errexit
 set -o nounset
 
-# disable modules so running `go get` does not update `go.mod` and `go.sum
-GO111MODULE=off go get github.com/mitchellh/gox
+go install github.com/mitchellh/gox@latest
 git clone https://github.com/bats-core/bats-core.git /tmp/bats-core && /tmp/bats-core/install.sh $HOME


### PR DESCRIPTION
Update the README for installing from source as well as our usage in
`scripts/bootstrap`.

Closes: #103

Signed-off-by: Jesse Szwedko <jesse.szwedko@gmail.com>
