### PR TITLE
use a Co-authored-by: message in git duet and git as

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"fmt"
 )
 
 // Configuration represents package configuration (shared by commands)
@@ -126,4 +127,21 @@ func checkGitDir(path string) (hasGitDir bool) {
 		}
 	}
 	return true;
+}
+
+func PrintCommitters(committers []*Pair) {
+	if committers == nil || len(committers) == 0 {
+		return
+	}
+
+	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committers[0].Name)
+	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committers[0].Email)
+
+	if len(committers) > 1 {
+		fmt.Printf("\n# Co-authored-by:\n")
+
+		for index := 0; index < len(committers); index++ {
+			fmt.Printf("#  %s <%s>\n", committers[index].Name, committers[index].Email)
+		}
+	}
 }

--- a/git-as/main.go
+++ b/git-as/main.go
@@ -61,7 +61,7 @@ func main() {
 		}
 
 		printAuthor(author)
-		printNextCommitter(committers)
+		duet.PrintCommitters(committers)
 		if configuration.CoAuthoredBy {
 			installHook("prepare-commit-msg")
 			// SetAuthor is needed in case neither GIT_DUET_CO_AUTHORED_BY nor GIT_DUET_SET_GIT_USER_CONFIG was set previously
@@ -111,7 +111,7 @@ func main() {
 
 	if !*quiet {
 		printAuthor(author)
-		printNextCommitter(committers)
+		duet.PrintCommitters(committers)
 	}
 
 	if configuration.CoAuthoredBy {
@@ -129,15 +129,6 @@ func printAuthor(author *duet.Pair) {
 
 	fmt.Printf("GIT_AUTHOR_NAME='%s'\n", author.Name)
 	fmt.Printf("GIT_AUTHOR_EMAIL='%s'\n", author.Email)
-}
-
-func printNextCommitter(committers []*duet.Pair) {
-	if committers == nil || len(committers) == 0 {
-		return
-	}
-
-	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committers[0].Name)
-	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committers[0].Email)
 }
 
 func installHook(hookType string) {

--- a/git-duet/main.go
+++ b/git-duet/main.go
@@ -70,7 +70,7 @@ func main() {
 		}
 
 		printAuthor(author)
-		printNextComitter(committers)
+		duet.PrintCommitters(committers)
 		if configuration.CoAuthoredBy {
 			installHook("prepare-commit-msg")
 			// SetAuthor is needed in case neither GIT_DUET_CO_AUTHORED_BY nor GIT_DUET_SET_GIT_USER_CONFIG was set previously
@@ -120,7 +120,7 @@ func main() {
 
 	if !*quiet {
 		printAuthor(author)
-		printNextComitter(committers)
+		duet.PrintCommitters(committers)
 	}
 
 	if configuration.CoAuthoredBy {
@@ -138,15 +138,6 @@ func printAuthor(author *duet.Pair) {
 
 	fmt.Printf("GIT_AUTHOR_NAME='%s'\n", author.Name)
 	fmt.Printf("GIT_AUTHOR_EMAIL='%s'\n", author.Email)
-}
-
-func printNextComitter(committers []*duet.Pair) {
-	if committers == nil || len(committers) == 0 {
-		return
-	}
-
-	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committers[0].Name)
-	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committers[0].Email)
 }
 
 func installHook(hookType string) {

--- a/test/git-as.bats
+++ b/test/git-as.bats
@@ -369,13 +369,25 @@ load test_helper
   assert_success ""
 }
 
-@test "as duet: prints current config" {
+@test "as duet: prints current config for 2 commiters" {
   git as -q jd fb
   run git as
   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
   assert_line "GIT_COMMITTER_NAME='Frances Bar'"
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+}
+
+@test "as duet: prints current config for 3 commiters" {
+  git as -q jd fb zs
+  run git as
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+  assert_line "# Co-authored-by:"
+  assert_line "#  Frances Bar <f.bar@hamster.info.local>"
+  assert_line "#  Zubaz Shirts <z.shirts@pika.info.local>"
 }
 
 @test "as duet: honors source when printing config" {

--- a/test/git-duet-commit.bats
+++ b/test/git-duet-commit.bats
@@ -18,6 +18,15 @@ load test_helper
   assert_success 'Frances Bar <f.bar@hamster.info.local>'
 }
 
+@test "lists all the authors in the commit message" {
+  git duet -q jd fb zs
+  add_file
+  git duet-commit -q -m 'Testing set of omega as committer'
+  run git log -1 --format='%cn <%ce>'
+  assert_success 'Frances Bar <f.bar@hamster.info.local>'
+  assert_success 'Zubaz Shirts <z.shirts@pika.info.local>'
+}
+
 @test "does not rotate author by default" {
   git duet -q jd fb
 

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -160,6 +160,18 @@ load test_helper
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
 
+@test "output is displayed for 3 commiters" {
+  run git duet jd fb zs
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+
+  assert_line "# Co-authored-by:"
+  assert_line "#  Frances Bar <f.bar@hamster.info.local>"
+  assert_line "#  Zubaz Shirts <z.shirts@pika.info.local>"
+}
+
 @test "output is not displayed when quieted" {
   run git duet -q jd fb
   assert_success ""


### PR DESCRIPTION
it's a little bit confusing that you don't see all the authors when you run `git duet` and `git as`. This change will make this less confusing :) 