### PR TITLE
Allow multiple committers if GIT_DUET_ALLOW_MULTIPLE_COMMITTERS is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,29 @@ as the author and committer respectively. If you have `GIT_DUET_ROTATE_AUTHOR`
 set then git-duet will rotate with each commit. The first commit will have
 jd as the author, and fb as the committer. The second commit will have fb
 as the author and zp as the committer and so on.
+(*Note:* This feature uses `,` as the delimiter which will fail to parse
+properly if the user's name or e-mail address contains a `,`.)
 
-*Note:* This feature uses `,` as the delimiter which will fail to parse
-properly if the user's name or e-mail address contains a `,`.
+Additionally, if you set `GIT_DUET_ALLOW_MULTIPLE_COMMITTERS`, then git-duet
+will add a sign-off trailer in the commit message for every committer that
+is specified after the author:
+
+Example:
+```
+$ git show --format=full
+commit ce7856371e3e3a6d05f1b66af96f086df071e783
+Author: Jane Doe <jane@awesometown.local>
+Commit: Frances Bar <f.bar@awesometown.local>
+
+    initial commit
+
+    Signed-off-by: Frances Bar <f.bar@awesometown.local>
+    Signed-off-by: Zubaz Shirts <z.shirts@pika.info.local>
+
+diff --git a/foo b/foo
+new file mode 100644
+index 0000000..e69de29
+```
 
 ### Email Configuration
 

--- a/configuration.go
+++ b/configuration.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	StaleCutoff                time.Duration
 	IsCurrentWorkingDirGitRepo bool
 	DefaultUpdate              bool
+	AllowMultipleCommitters    bool
 }
 
 // NewConfiguration initializes Configuration from the environment
@@ -56,6 +57,10 @@ func NewConfiguration() (config *Configuration, err error) {
 	}
 
 	if config.DefaultUpdate, err = strconv.ParseBool(getenvDefault("GIT_DUET_DEFAULT_UPDATE", "0")); err != nil {
+		return nil, err
+	}
+
+	if config.AllowMultipleCommitters, err = strconv.ParseBool(getenvDefault("GIT_DUET_ALLOW_MULTIPLE_COMMITTERS", "0")); err != nil {
 		return nil, err
 	}
 
@@ -125,5 +130,5 @@ func checkGitDir(path string) (hasGitDir bool) {
 			return checkGitDir(parent)
 		}
 	}
-	return true;
+	return true
 }

--- a/git-duet/main.go
+++ b/git-duet/main.go
@@ -122,7 +122,11 @@ func main() {
 
 	if !*quiet {
 		printAuthor(author)
-		printNextComitter(committers)
+		if configuration.AllowMultipleCommitters {
+			printAllCommitters(committers)
+		} else {
+			printNextComitter(committers)
+		}
 	}
 
 	if configuration.CoAuthoredBy {
@@ -149,6 +153,17 @@ func printNextComitter(committers []*duet.Pair) {
 
 	fmt.Printf("GIT_COMMITTER_NAME='%s'\n", committers[0].Name)
 	fmt.Printf("GIT_COMMITTER_EMAIL='%s'\n", committers[0].Email)
+}
+
+func printAllCommitters(committers []*duet.Pair) {
+	if committers == nil || len(committers) == 0 {
+		return
+	}
+
+	for i, p := range committers {
+		fmt.Printf("GIT_COMMITTER_#%d_NAME='%s'\n", i+1, p.Name)
+		fmt.Printf("GIT_COMMITTER_#%d_EMAIL='%s'\n", i+1, p.Email)
+	}
 }
 
 func installHook(hookType string) {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -80,8 +80,17 @@ func (duetcmd Command) Execute() error {
 
 	var committer *duet.Pair
 	if committers != nil && len(committers) > 0 && duetcmd.Signoff {
-		duetcmd.Args = append([]string{"--signoff"}, duetcmd.Args...)
 		committer = committers[0]
+		if len(committers) > 1 && configuration.AllowMultipleCommitters {
+			// Reverse the iteration because the committers should sign-off in order
+			for i := len(committers) - 1; i >= 0; i-- {
+				var trailer = "\"Signed-off-by: " + committers[i].Name + " <" + committers[i].Email + ">\""
+				duetcmd.Args = append([]string{trailer}, duetcmd.Args...)
+				duetcmd.Args = append([]string{"--trailer"}, duetcmd.Args...)
+			}
+		} else {
+			duetcmd.Args = append([]string{"--signoff"}, duetcmd.Args...)
+		}
 	} else {
 		committer = author
 	}

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -165,6 +165,24 @@ load test_helper
   assert_success ""
 }
 
+@test "output only displays next committer by default" {
+  run git duet jd fb zs
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
+}
+
+@test "output displays all committers when GIT_DUET_ALLOW_MULTIPLE_COMMITTERS" {
+  GIT_DUET_ALLOW_MULTIPLE_COMMITTERS=1 run git duet jd fb zs
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_#1_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_#1_EMAIL='f.bar@hamster.info.local'"
+  assert_line "GIT_COMMITTER_#2_NAME='Zubaz Shirts'"
+  assert_line "GIT_COMMITTER_#2_EMAIL='z.shirts@pika.info.local'"
+}
+
 @test "prints current config" {
   git duet -q jd fb
   run git duet


### PR DESCRIPTION
If GIT_DUET_ALLOW_MULTIPLE_COMMITTERS=1 is set, git duet will:
* [git duet-commit, git duet-merge] Add sign-off trailers for every committer specified after the author
* [git duet] Print the author and all committers specified