### PR TITLE
Fix GIT_DUET_ALLOW_MULTIPLE_COMMITTERS bugs

### DIFF
--- a/git-duet/main.go
+++ b/git-duet/main.go
@@ -70,7 +70,11 @@ func main() {
 		}
 
 		printAuthor(author)
-		printNextComitter(committers)
+		if configuration.AllowMultipleCommitters {
+			printAllCommitters(committers)
+		} else {
+			printNextComitter(committers)
+		}
 		if configuration.CoAuthoredBy {
 			installHook("prepare-commit-msg")
 			// SetAuthor is needed in case neither GIT_DUET_CO_AUTHORED_BY nor GIT_DUET_SET_GIT_USER_CONFIG was set previously

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -84,7 +84,7 @@ func (duetcmd Command) Execute() error {
 		if len(committers) > 1 && configuration.AllowMultipleCommitters {
 			// Reverse the iteration because the committers should sign-off in order
 			for i := len(committers) - 1; i >= 0; i-- {
-				var trailer = "\"Signed-off-by: " + committers[i].Name + " <" + committers[i].Email + ">\""
+				var trailer = "Signed-off-by: " + committers[i].Name + " <" + committers[i].Email + ">"
 				duetcmd.Args = append([]string{trailer}, duetcmd.Args...)
 				duetcmd.Args = append([]string{"--trailer"}, duetcmd.Args...)
 			}

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -173,8 +173,20 @@ load test_helper
   assert_line "GIT_COMMITTER_EMAIL='f.bar@hamster.info.local'"
 }
 
-@test "output displays all committers when GIT_DUET_ALLOW_MULTIPLE_COMMITTERS" {
+@test "output for command with initials displays all committers when GIT_DUET_ALLOW_MULTIPLE_COMMITTERS" {
   GIT_DUET_ALLOW_MULTIPLE_COMMITTERS=1 run git duet jd fb zs
+  assert_line "GIT_AUTHOR_NAME='Jane Doe'"
+  assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
+  assert_line "GIT_COMMITTER_#1_NAME='Frances Bar'"
+  assert_line "GIT_COMMITTER_#1_EMAIL='f.bar@hamster.info.local'"
+  assert_line "GIT_COMMITTER_#2_NAME='Zubaz Shirts'"
+  assert_line "GIT_COMMITTER_#2_EMAIL='z.shirts@pika.info.local'"
+}
+
+@test "output for command without args displays all committers when GIT_DUET_ALLOW_MULTIPLE_COMMITTERS" {
+  export GIT_DUET_ALLOW_MULTIPLE_COMMITTERS=1
+  git duet jd fb zs
+  run git duet
   assert_line "GIT_AUTHOR_NAME='Jane Doe'"
   assert_line "GIT_AUTHOR_EMAIL='jane@hamsters.biz.local'"
   assert_line "GIT_COMMITTER_#1_NAME='Frances Bar'"


### PR DESCRIPTION
Fixed the following bugs for GIT_DUET_ALLOW_MULTIPLE_COMMITTERS:
* The command git duet (without arguments) does not list the full list of committers (if there are more than 2 people) set previously
* The "Signed-off-by: ..." line in the commit message contains extra double quotes at the beginning and the end of the line