### PR TITLE
Update version tests to allow version parts greater than 9

### DIFF
--- a/test/git-as.bats
+++ b/test/git-as.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "as: version is displayed" {
   run git as -v
-  if ! echo "$output" | grep -o -E "^[0-9]\.[0-9]\.[0-9].* \('[a-f0-9]{40}'\)$" ; then
+  if ! echo "$output" | grep -o -E "^[0-9]+\.[0-9]+\.[0-9]+.* \('[a-f0-9]{40}'\)$" ; then
     echo "expected '$output' to match version spec" | flunk
   fi
 }

--- a/test/git-duet.bats
+++ b/test/git-duet.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "version is displayed" {
   run git duet -v
-  if ! echo "$output" | grep -o -E "^[0-9]\.[0-9]\.[0-9].* \('[a-f0-9]{40}'\)$" ; then
+  if ! echo "$output" | grep -o -E "^[0-9]+\.[0-9]+\.[0-9]+.* \('[a-f0-9]{40}'\)$" ; then
     echo "expected '$output' to match version spec" | flunk
   fi
 }

--- a/test/git-solo.bats
+++ b/test/git-solo.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "version is displayed" {
   run git solo -v
-  if ! echo "$output" | grep -o -E "^[0-9]\.[0-9]\.[0-9].* \('[a-f0-9]{40}'\)$" ; then
+  if ! echo "$output" | grep -o -E "^[0-9]+\.[0-9]+\.[0-9]+.* \('[a-f0-9]{40}'\)$" ; then
     echo "expected '$output' to match version spec" | flunk
   fi
 }


### PR DESCRIPTION
These tests failed when I attempted to tag 0.10.0.